### PR TITLE
Post-split actions and additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Text editor files
+*~
+*.swp
+.vscode
+
+_*.nb
+*.fdb_latexmk
+*.gz
+*.pdf
+.DS_Store
+*~
+*.sw[op]
+*.log
+.git-notifier*
+git-notifier.log
+.gitversion
+
+
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Run dev.dials.install_pre_commits to enable repository pre-commits.
+
+repos:
+
+# If a python3 installation is available than can run black
+# then run that. Otherwise skip.
+-   repo: https://github.com/dials/black
+    rev: v2
+    hooks:
+    -   id: black
+        args: [--safe, --quiet]
+        language_version: libtbx.python
+
+# Syntax check and some basic flake8,
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    -   id: check-ast
+        language_version: libtbx.python
+    -   id: flake8
+        language_version: libtbx.python
+        args: ['--max-line-length=88', '--select=W291,W292,W293,F401']


### PR DESCRIPTION
This is a 'living' pull request for changes to the repository, only to be merged after the split process has been actioned.

- `.gitignore` - Take most of the standard github [python](https://github.com/github/gitignore/blob/master/Python.gitignore) gitignore, with some of the `dials`/editor entries added for good measure.
- Copied the pre-commit configuration from dials