### PR TITLE
Use struct not numpy to unpack the bytestring.

### DIFF
--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -17,6 +17,7 @@ from dxtbx.format.FormatCBFMultiTile import FormatCBFMultiTile
 from dxtbx.format.FormatStill import FormatStill
 from dxtbx.model import Detector
 from libtbx.utils import Sorry
+from scitbx.array_family import flex
 from scitbx.matrix import col, sqr
 
 
@@ -317,10 +318,7 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
 
     def get_raw_data(self):
         if self._raw_data is None:
-            from scitbx.array_family import flex
-
             self._raw_data = []
-
             cbf = self._get_cbf_handle()
             cbf.find_category("array_structure")
             cbf.find_column("encoding_type")

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, division, print_function
 
 import collections
+import struct
 
 import pycbf
 from dxtbx.format.FormatCBFMultiTile import FormatCBFMultiTile
@@ -316,7 +317,6 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
 
     def get_raw_data(self):
         if self._raw_data is None:
-            import numpy
             from scitbx.array_family import flex
 
             self._raw_data = []
@@ -343,12 +343,14 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
 
                 if types[i] == "signed 32-bit integer":
                     array_string = cbf.get_integerarray_as_string()
-                    array = flex.int(numpy.frombuffer(array_string, numpy.int32))
+                    nelem = int(len(array_string) / 4)
+                    array = flex.int(struct.unpack("%dl" % nelem, array_string))
                     parameters = cbf.get_integerarrayparameters_wdims_fs()
                     array_size = (parameters[11], parameters[10], parameters[9])
                 elif types[i] == "signed 64-bit real IEEE":
                     array_string = cbf.get_realarray_as_string()
-                    array = flex.double(numpy.frombuffer(array_string, numpy.float))
+                    nelem = int(len(array_string) / 8)
+                    array = flex.double(struct.unpack("%dd" % nelem, array_string))
                     parameters = cbf.get_realarrayparameters_wdims_fs()
                     array_size = (parameters[7], parameters[6], parameters[5])
                 else:

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -344,7 +344,7 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
                 if types[i] == "signed 32-bit integer":
                     array_string = cbf.get_integerarray_as_string()
                     nelem = int(len(array_string) / 4)
-                    array = flex.int(struct.unpack("%dl" % nelem, array_string))
+                    array = flex.int(struct.unpack("%di" % nelem, array_string))
                     parameters = cbf.get_integerarrayparameters_wdims_fs()
                     array_size = (parameters[11], parameters[10], parameters[9])
                 elif types[i] == "signed 64-bit real IEEE":


### PR DESCRIPTION
This avoids the use of numpy within Python code that is already being called from within C++, which may be problematic (see #25).
