### PR TITLE
Minimal fixes needed to get HDF5 files written in py3 to be read

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -105,7 +105,7 @@ def find_entries(nx_file, entry):
 
     def visitor(name, obj):
         if "NX_class" in obj.attrs:
-            if obj.attrs["NX_class"] in [
+            if numpy.string_(obj.attrs["NX_class"]) in [
                 numpy.string_("NXentry"),
                 numpy.string_("NXsubentry"),
             ]:
@@ -126,8 +126,8 @@ def find_class(nx_file, nx_class):
     nx_class = numpy.string_(nx_class)
 
     def visitor(name, obj):
-        if "NX_class" in obj.attrs:
-            if obj.attrs["NX_class"] == nx_class:
+        if numpy.string_("NX_class") in obj.attrs:
+            if numpy.string_(obj.attrs["NX_class"]) == nx_class:
                 hits.append(obj)
 
     local_visit(nx_file, visitor)
@@ -564,11 +564,11 @@ def get_change_of_basis(transformation):
     # Change of basis to convert from NeXus to IUCr/ImageCIF convention
     n2i_cob = sqr((-1, 0, 0, 0, 1, 0, 0, 0, -1))
 
-    axis_type = transformation.attrs["transformation_type"]
+    axis_type = numpy.string_(transformation.attrs["transformation_type"])
 
     vector = n2i_cob * col(transformation.attrs["vector"]).normalize()
     setting = transformation[0]
-    units = transformation.attrs["units"]
+    units = numpy.string_(transformation.attrs["units"])
 
     if "offset" in transformation.attrs:
         offset = n2i_cob * col(transformation.attrs["offset"])
@@ -639,7 +639,7 @@ def get_change_of_basis(transformation):
             )
         )
     else:
-        raise ValueError("Unrecognized tranformation type: %d" % axis_type)
+        raise ValueError("Unrecognized tranformation type: %s" % axis_type)
 
     return cob
 
@@ -655,7 +655,7 @@ def get_depends_on_chain_using_equipment_components(transformation):
     current = transformation
 
     while True:
-        parent_id = current.attrs["depends_on"]
+        parent_id = numpy.string_(current.attrs["depends_on"])
 
         if parent_id == numpy.string_("."):
             return chain
@@ -682,7 +682,7 @@ def get_cumulative_change_of_basis(transformation):
 
     cob = get_change_of_basis(transformation)
 
-    parent_id = transformation.attrs["depends_on"]
+    parent_id = numpy.string_(transformation.attrs["depends_on"])
 
     if parent_id == numpy.string_("."):
         return None, cob


### PR DESCRIPTION
We are writing NeXus master files for the SwissFEL JF16M detector using
https://github.com/cctbx/cctbx_project/blob/master/xfel/swissfel/jf16m_cxigeom2nexus.py

which is the same script used to make
https://zenodo.org/record/3352358#.Xmp9gRdKhpk

Works great in py2.  Files written in py2 also can be read in py3.  However, files written in py3 cannot be read in py3 without these changes.

From what I can tell, h5py is writing utf8 encoded strings in py3 to hdf5.  We are using numpy.string_ to test these strings in nexus,py, as recommended by the hdf5 documentation (http://docs.h5py.org/en/stable/strings.html).  In py3 this always returns bytestrings, but these new hdf5 files have attributes encoded as utf8.  Using more calls to numpy.string_ in nexus.py seems to resolve problems comparing strings to each other in py3.

I can make a py3 generated hdf5 file available if there is interest.