### PR TITLE
DIALS 2.2.9

### DIFF
--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -76,7 +76,7 @@ class FormatSMVADSC(FormatSMV):
         pedestal that is present"""
 
         if pedestal is None:
-            pedestal = int(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
+            pedestal = float(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
 
         overload = 65535 - pedestal
         underload = -1 - pedestal
@@ -178,7 +178,7 @@ class FormatSMVADSC(FormatSMV):
             self._adsc_trusted_range(),
             [],
             gain=self._adsc_module_gain(),
-            pedestal=int(self._header_dictionary.get("IMAGE_PEDESTAL", 0)),
+            pedestal=float(self._header_dictionary.get("IMAGE_PEDESTAL", 0)),
         )
 
     def _beam(self):

--- a/format/FormatSMVRigakuSaturnNoTS.py
+++ b/format/FormatSMVRigakuSaturnNoTS.py
@@ -157,7 +157,7 @@ class FormatSMVRigakuSaturnNoTS(FormatSMVRigaku):
             pixel_size,
             image_size,
             (underload, overload),
-            pedestal=int(self._header_dictionary.get("IMAGE_PEDESTAL"), 0),
+            pedestal=float(self._header_dictionary.get("IMAGE_PEDESTAL"), 0),
         )
 
     def _beam(self):

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -277,7 +277,7 @@ def construct_axes(nx_file, item, vector=None):
                 if hasattr(value, "__iter__") and len(value):
                     value = value[0]
                 if units == numpy.string_("rad"):
-                    value *= math.pi / 180
+                    value *= 180 / math.pi
                 elif units not in [
                     numpy.string_("deg"),
                     numpy.string_("degree"),

--- a/imageset.py
+++ b/imageset.py
@@ -390,7 +390,11 @@ class ImageSetFactory(object):
             # Get the template format
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
 
             # Get the template image range
             if image_range is None:
@@ -437,7 +441,11 @@ class ImageSetFactory(object):
         if count > 0:
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
             filenames = [template_format % index for index in indices]
         else:
             filenames = [template]
@@ -462,7 +470,11 @@ class ImageSetFactory(object):
         if count > 0:
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
             filenames = [template_format % index for index in indices]
         else:
             filenames = [template]
@@ -476,7 +488,11 @@ class ImageSetFactory(object):
         # Get the template format
         pfx = template.split("#")[0]
         sfx = template.split("#")[-1]
-        template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+        template_format = "%s%%0%dd%s" % (
+            pfx.replace("%", "%%"),
+            template.count("#"),
+            sfx.replace("%", "%%"),
+        )
 
         # Set the image range
         array_range = range(min(indices) - 1, max(indices))
@@ -546,7 +562,11 @@ class ImageSetFactory(object):
         if count > 0:
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
             filenames = [template_format % index for index in indices]
         else:
             template_format = None

--- a/newsfragments/216.bugfix
+++ b/newsfragments/216.bugfix
@@ -1,0 +1,1 @@
+Don't crash handling FormatSMVADSC images with floating-point pedestal values

--- a/tests/format/test_FormatSMVADSC.py
+++ b/tests/format/test_FormatSMVADSC.py
@@ -1,0 +1,20 @@
+import os
+
+import dxtbx
+
+
+def test_noninteger_pedestal(dials_regression, tmpdir):
+    filename = os.path.join(
+        dials_regression, "image_examples/APS_14BMC/q315_1_001.img",
+    )
+    # Read this file in as data
+    with open(filename, "rb") as f:
+        data = f.read()
+
+    # Write out with an inserted header item of a noninteger pedestal
+    test_file = tmpdir / "test_pedestal_001.img"
+    with test_file.open("wb") as f:
+        f.write(data.replace(b"DIM=2;\n", b"DIM=2;\nIMAGE_PEDESTAL=42.0;\n"))
+
+    # Make sure this loads
+    dxtbx.load(test_file)


### PR DESCRIPTION
* read correct angles in Nexus files where angles are saved in radians (cctbx/dxtbx#192)
* fix file processing issues where `%` characters are in the path (cctbx/dxtbx#214)
* allow reading SMV ADSC format files with non-integer pedestal (cctbx/dxtbx#216)