### PR TITLE
Add Spectrum as a read-only class obtainable from an imageset

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -153,6 +153,7 @@ if not env_etc.no_boost_python and hasattr(env_etc, "boost_adaptbx_include"):
         target="#/lib/dxtbx_model_ext",
         source=[
             "model/boost_python/beam.cc",
+            "model/boost_python/spectrum.cc",
             "model/boost_python/goniometer.cc",
             "model/boost_python/kappa_goniometer.cc",
             "model/boost_python/multi_axis_goniometer.cc",

--- a/format/Format.py
+++ b/format/Format.py
@@ -497,26 +497,32 @@ class Format(object):
 
     def _goniometer(self):
         """Overload this method to read the image file however you like so
-        long as the result is an goniometer."""
+        long as the result is a goniometer."""
         return None
 
     def _detector(self):
         """Overload this method to read the image file however you like so
-        long as the result is an detector."""
+        long as the result is a detector."""
         return None
 
     def _beam(self):
         """Overload this method to read the image file however you like so
-        long as the result is an beam."""
+        long as the result is a beam."""
         return None
 
     def _scan(self):
         """Overload this method to read the image file however you like so
-        long as the result is an scan."""
+        long as the result is a scan."""
         return None
 
     def get_static_mask(self):
         """Overload this method to override the static mask."""
+        return None
+
+    def get_spectrum(self):
+        """ Overload this method to read the image file however you like so
+        long as the result is a spectrum
+        """
         return None
 
     def get_goniometer_shadow_masker(self, goniometer=None):

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -70,6 +70,9 @@ class FormatMultiImage(Format):
     def get_beam(self, index=None):
         return self._beam_instance
 
+    def get_spectrum(self, index=None):
+        raise NotImplementedError
+
     def get_scan(self, index=None):
         return self._scan_instance
 

--- a/format/FormatNexus.py
+++ b/format/FormatNexus.py
@@ -114,6 +114,10 @@ class FormatNexus(FormatHDF5):
     def get_beam(self, index=None):
         return self._beam(index)
 
+    def get_spectrum(self, index=None):
+        self._beam_model = self._beam_factory.load_model(index)
+        return self._beam_factory.spectrum
+
     def get_scan(self, index=None):
         if index is None:
             return self._scan()

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -19,6 +19,7 @@ from scitbx.matrix import col, sqr
 import dxtbx.model
 from dxtbx.model import (
     Beam,
+    Spectrum,
     Crystal,
     Detector,
     Panel,
@@ -542,6 +543,7 @@ class BeamFactory(object):
         self.obj = obj
         self.model = None
         self.index = None
+        self.spectrum = None
 
     def load_model(self, index=None):
         # Cached model
@@ -549,29 +551,75 @@ class BeamFactory(object):
             return self.model
 
         # Get the items from the NXbeam class
-        wavelength = self.obj.handle["incident_wavelength"]
-        wavelength_weights = self.obj.handle.get("incident_wavelength_weights")
-        if wavelength.shape in (tuple(), (1,)):
-            wavelength_value = wavelength[()]
-        elif len(wavelength.shape) == 1:
-            if wavelength_weights is None:
-                if index is None:
-                    index = 0
-                wavelength_value = wavelength[index]
+        primary_key = "incident_wavelength"
+        wavelength = self.obj.handle[primary_key]
+        spectrum_wavelengths = wavelength
+        spectrum_weights = self.obj.handle.get(primary_key + "_weight")
+
+        # If the wavelength array does not represent spectra, look for spectra
+        # in the variant chain
+        variant_test = wavelength
+        has_variant_spectra = False
+        while spectrum_weights is None:
+            if "variant" in variant_test.attrs:
+                variant_key = variant_test.attrs["variant"]
+                variant_wavelengths = self.obj.handle[variant_key]
+                variant_weights = self.obj.handle.get(variant_key + "_weight")
+                if variant_weights is None:
+                    variant_test = variant_wavelengths  # Keep looking
+                else:
+                    # Found spectra
+                    spectrum_wavelengths = variant_wavelengths
+                    spectrum_weights = variant_weights  # cause while loop to end
+                    has_variant_spectra = True
             else:
-                raise NotImplementedError("Spectra not implemented")
-        else:
-            raise NotImplementedError("Spectra not implemented")
-        wavelength_units = wavelength.attrs["units"]
+                break
 
-        # Convert wavelength to Angstroms
-        wavelength_value = float(
-            convert_units(wavelength_value, wavelength_units, "angstrom")
-        )
-
-        # Construct the beam model
+        if index is None:
+            index = 0
         self.index = index
-        self.model = Beam(direction=(0, 0, 1), wavelength=wavelength_value)
+
+        def get_wavelength(wavelength):
+            if wavelength.shape in (tuple(), (1,)):
+                wavelength_value = wavelength[()]
+            else:
+                wavelength_value = wavelength[index]
+            wavelength_units = wavelength.attrs["units"]
+            wavelength_value = float(
+                convert_units(wavelength_value, wavelength_units, "angstrom")
+            )
+            return wavelength_value
+
+        if spectrum_weights is None:
+            # Construct the beam model
+            wavelength_value = get_wavelength(wavelength)
+            self.model = Beam(direction=(0, 0, 1), wavelength=wavelength_value)
+        else:
+            self.model = Beam()
+            self.model.set_direction((0, 0, 1))
+
+            wavelength_units = spectrum_wavelengths.attrs["units"]
+
+            if len(spectrum_wavelengths.shape) > 1:
+                spectrum_wavelengths = spectrum_wavelengths[index]
+            else:
+                spectrum_wavelengths = spectrum_wavelengths[()]
+            if len(spectrum_weights.shape) > 1:
+                spectrum_weights = spectrum_weights[index]
+            else:
+                spectrum_weights = spectrum_weights[()]
+
+            spectrum_wavelengths = convert_units(
+                spectrum_wavelengths, wavelength_units, "angstrom"
+            )
+            spectrum_energies = 12398.4187 / spectrum_wavelengths
+            self.spectrum = Spectrum(spectrum_energies, spectrum_wavelengths)
+
+            if has_variant_spectra:
+                wavelength_value = get_wavelength(wavelength)
+                self.model.set_wavelength(wavelength_value)
+            else:
+                self.model.set_wavelength(self.spectrum.get_weighted_wavelength())
         return self.model
 
 

--- a/imageset.py
+++ b/imageset.py
@@ -102,6 +102,19 @@ class _(object):
         """Get format class name"""
         return self.data().get_format_class()
 
+    def get_spectrum(self, index):
+        """Get the spectrum if available"""
+        kwargs = self.params()
+        if self.data().has_single_file_reader():
+            format_instance = self.get_format_class().get_instance(
+                self.data().get_master_path(), **kwargs
+            )
+        else:
+            format_instance = self.get_format_class().get_instance(
+                self.get_path(index), **kwargs
+            )
+        return format_instance.get_spectrum(self.indices()[index])
+
     def params(self):
         """Get the parameters"""
         return self.data().get_params()

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -28,6 +28,7 @@ from dxtbx.util import format_float_with_standard_uncertainty
 from dxtbx_model_ext import (
     Beam,
     BeamBase,
+    Spectrum,
     Crystal,
     CrystalBase,
     Detector,

--- a/model/boost_python/model_ext.cc
+++ b/model/boost_python/model_ext.cc
@@ -28,6 +28,7 @@ namespace dxtbx { namespace model { namespace boost_python {
   void export_pixel_to_millimeter();
   void export_experiment();
   void export_experiment_list();
+  void export_spectrum();
 
   BOOST_PYTHON_MODULE(dxtbx_model_ext) {
     export_beam();
@@ -43,6 +44,7 @@ namespace dxtbx { namespace model { namespace boost_python {
     export_pixel_to_millimeter();
     export_experiment();
     export_experiment_list();
+    export_spectrum();
   }
 
 }}}  // namespace dxtbx::model::boost_python

--- a/model/spectrum.h
+++ b/model/spectrum.h
@@ -1,0 +1,75 @@
+/*
+ * spectrum.h
+ */
+#ifndef DXTBX_MODEL_SPECTRUM_H
+#define DXTBX_MODEL_SPECTRUM_H
+
+#include <iostream>
+#include <cmath>
+#include <scitbx/vec3.h>
+#include <scitbx/array_family/shared.h>
+#include <scitbx/array_family/simple_io.h>
+#include <scitbx/array_family/simple_tiny_io.h>
+#include <dxtbx/error.h>
+#include "model_helpers.h"
+
+namespace dxtbx { namespace model {
+  typedef scitbx::af::shared<double> vecd;
+
+  /** A class to represent a 2D spectrum. */
+  class Spectrum {
+  public:
+    /** Default constructor: initialise all to zero */
+    Spectrum() {}
+
+    /**
+     * Initialise all the spectrum parameters.
+     * @param energies The spectrum energies (eV)
+     * @param energies The spectrum weights (unitless)
+     */
+    Spectrum(vecd energies, vecd weights)
+        : energies_(energies),
+          weights_(weights) {}
+
+    virtual ~Spectrum() {}
+
+    /* Get the spectrum energies (eV) */
+    vecd get_energies() const {
+      return energies_;
+    }
+
+    /* Get the spectrum weights (unitless) */
+    vecd get_weights() const {
+      return weights_;
+    }
+
+    double get_weighted_wavelength() const {
+      if (energies_.size() == 0)
+        return 0;
+      double weighted_sum = 0;
+      double summed_weights = 0;
+      for (size_t i = 0; i < energies_.size(); i++) {
+        weighted_sum += energies_[i] * weights_[i];
+        summed_weights += weights_[i];
+      }
+      DXTBX_ASSERT(weighted_sum > 0 && summed_weights > 0);
+      return 12398.4187 / (weighted_sum / summed_weights); //  eV per Å conversion factor
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const Spectrum &s);
+
+  private:
+    vecd energies_;
+    vecd weights_;
+  };
+
+  /** Print Spectrum information */
+  inline std::ostream &operator<<(std::ostream &os, const Spectrum &s) {
+    os << "Spectrum:\n";
+    os << "    weighted wavelength: " << s.get_weighted_wavelength() << "\n";
+    return os;
+  }
+
+}}  // namespace dxtbx::model
+
+#endif  // DXTBX_MODEL_BEAM_H


### PR DESCRIPTION
Details:
- Add Spectrum C++ object that implements methods get_energies (eV), get_weights (unitless), and get_weighted_wavelenth (angstroms). Spectrum can only be set from constructor.
- Add get_spectrum method to Format and FormatMultiImage
- Add get_spectrum method to ImageSet. Does not cache it like it does for detector, beam, etc.
- Implement get_spectrum in NeXus.  Specifically implements nexusformat/definitions#717, using optional variants to specify a calibrated wavelength and a spectrum.