### PR TITLE
When file indices are provided, only read models for the specified images

### DIFF
--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -237,10 +237,16 @@ class FormatMultiImage(Format):
                 goniometer = []
                 scan = []
                 for i in range(format_instance.get_num_images()):
-                    beam.append(format_instance.get_beam(i))
-                    detector.append(format_instance.get_detector(i))
-                    goniometer.append(format_instance.get_goniometer(i))
-                    scan.append(format_instance.get_scan(i))
+                    if (single_file_indices is None) or (i in single_file_indices):
+                        beam.append(format_instance.get_beam(i))
+                        detector.append(format_instance.get_detector(i))
+                        goniometer.append(format_instance.get_goniometer(i))
+                        scan.append(format_instance.get_scan(i))
+                    else:
+                        beam.append(None)
+                        detector.append(None)
+                        goniometer.append(None)
+                        scan.append(None)
 
             if single_file_indices is None:
                 single_file_indices = list(range(format_instance.get_num_images()))


### PR DESCRIPTION
We were loading models (beam, detector, gonio, scan) for every image in a multiimage file, even when only 1 image was requested. This makes a big difference: FormatMultiImage.get_imageset now takes 0.1s instead of 0.8s when making a 1-image "set" from a 600-image .h5 file.

Leaving this as a draft while waiting to see tests.