### PR TITLE
DIALS 3.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+DIALS 3.1.1 (2020-09-01)
+========================
+
+Bugfixes
+--------
+
+- Don't crash handling FormatSMVADSC images with floating-point pedestal values (#216)
+- Allow importing filenames with special format characters like % (#214)
+
+
 DIALS 3.1 (2020-08-17)
 ======================
 

--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -76,7 +76,7 @@ class FormatSMVADSC(FormatSMV):
         pedestal that is present"""
 
         if pedestal is None:
-            pedestal = int(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
+            pedestal = float(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
 
         overload = 65535 - pedestal
         underload = -1 - pedestal
@@ -178,7 +178,7 @@ class FormatSMVADSC(FormatSMV):
             self._adsc_trusted_range(),
             [],
             gain=self._adsc_module_gain(),
-            pedestal=int(self._header_dictionary.get("IMAGE_PEDESTAL", 0)),
+            pedestal=float(self._header_dictionary.get("IMAGE_PEDESTAL", 0)),
         )
 
     def _beam(self):

--- a/format/FormatSMVRigakuSaturnNoTS.py
+++ b/format/FormatSMVRigakuSaturnNoTS.py
@@ -156,7 +156,7 @@ class FormatSMVRigakuSaturnNoTS(FormatSMVRigaku):
             pixel_size,
             image_size,
             (underload, overload),
-            pedestal=int(self._header_dictionary.get("IMAGE_PEDESTAL"), 0),
+            pedestal=float(self._header_dictionary.get("IMAGE_PEDESTAL"), 0),
         )
 
     def _beam(self):

--- a/imageset.py
+++ b/imageset.py
@@ -403,7 +403,11 @@ class ImageSetFactory(object):
             # Get the template format
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
 
             # Get the template image range
             if image_range is None:
@@ -450,7 +454,11 @@ class ImageSetFactory(object):
         if count > 0:
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
             filenames = [template_format % index for index in indices]
         else:
             filenames = [template]
@@ -475,7 +483,11 @@ class ImageSetFactory(object):
         if count > 0:
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
             filenames = [template_format % index for index in indices]
         else:
             filenames = [template]
@@ -489,7 +501,11 @@ class ImageSetFactory(object):
         # Get the template format
         pfx = template.split("#")[0]
         sfx = template.split("#")[-1]
-        template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+        template_format = "%s%%0%dd%s" % (
+            pfx.replace("%", "%%"),
+            template.count("#"),
+            sfx.replace("%", "%%"),
+        )
 
         # Set the image range
         array_range = range(min(indices) - 1, max(indices))
@@ -559,7 +575,11 @@ class ImageSetFactory(object):
         if count > 0:
             pfx = template.split("#")[0]
             sfx = template.split("#")[-1]
-            template_format = "%s%%0%dd%s" % (pfx, template.count("#"), sfx)
+            template_format = "%s%%0%dd%s" % (
+                pfx.replace("%", "%%"),
+                template.count("#"),
+                sfx.replace("%", "%%"),
+            )
             filenames = [template_format % index for index in indices]
         else:
             template_format = None

--- a/newsfragments/216.bugfix
+++ b/newsfragments/216.bugfix
@@ -1,0 +1,1 @@
+Don't crash handling FormatSMVADSC images with floating-point pedestal values

--- a/newsfragments/216.bugfix
+++ b/newsfragments/216.bugfix
@@ -1,1 +1,0 @@
-Don't crash handling FormatSMVADSC images with floating-point pedestal values

--- a/tests/format/test_FormatSMVADSC.py
+++ b/tests/format/test_FormatSMVADSC.py
@@ -1,0 +1,20 @@
+import os
+
+import dxtbx
+
+
+def test_noninteger_pedestal(dials_regression, tmpdir):
+    filename = os.path.join(
+        dials_regression, "image_examples/APS_14BMC/q315_1_001.img",
+    )
+    # Read this file in as data
+    with open(filename, "rb") as f:
+        data = f.read()
+
+    # Write out with an inserted header item of a noninteger pedestal
+    test_file = tmpdir / "test_pedestal_001.img"
+    with test_file.open("wb") as f:
+        f.write(data.replace(b"DIM=2;\n", b"DIM=2;\nIMAGE_PEDESTAL=42.0;\n"))
+
+    # Make sure this loads
+    dxtbx.load(test_file)

--- a/tests/test_imageset.py
+++ b/tests/test_imageset.py
@@ -493,6 +493,30 @@ def test_imagesetfactory(centroid_files, dials_data):
     assert len(sequence) == 4
 
 
+def test_make_sequence_with_percent_character(dials_data, tmp_path):
+    images = [
+        dials_data("centroid_test_data").join(f"centroid_{i:04}.cbf")
+        for i in range(1, 10)
+    ]
+    directory = tmp_path / "test%"
+    directory.mkdir()
+    for image in images:
+        (directory / image.basename).symlink_to(image)
+    template = str(directory / "centroid_####.cbf")
+    sequence = ImageSetFactory.make_sequence(template, list(range(1, 10)))
+    assert len(sequence) == 9
+
+    sequences = ImageSetFactory.new(
+        [str(directory / image.basename) for image in images]
+    )
+    assert len(sequences) == 1
+    assert len(sequences[0]) == 9
+
+    sequences = ImageSetFactory.from_template(template)
+    assert len(sequences) == 1
+    assert len(sequences[0]) == 9
+
+
 def test_pickle_imageset(centroid_files):
     sequence = ImageSetFactory.new(centroid_files)[0]
 


### PR DESCRIPTION
- Don't crash handling FormatSMVADSC images with floating-point pedestal values (cctbx/dxtbx#216)
- Allow importing filenames with special format characters like % (cctbx/dxtbx#214)
