### PR TITLE
Make FormatHDF5SaclaMPCCD lazy

### DIFF
--- a/format/FormatHDF5SaclaMPCCD.py
+++ b/format/FormatHDF5SaclaMPCCD.py
@@ -13,6 +13,7 @@ from scitbx import matrix
 from scitbx.array_family import flex
 
 from dxtbx.format.FormatHDF5 import FormatHDF5
+from dxtbx.format.FormatMultiImageLazy import FormatMultiImageLazy
 from dxtbx.format.FormatStill import FormatStill
 from dxtbx.model import ParallaxCorrectedPxMmStrategy
 from dxtbx.model.detector import Detector
@@ -27,7 +28,7 @@ from dxtbx.model.detector import Detector
 # 180724: update 'understand' to exclude Rayonix data
 
 
-class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
+class FormatHDF5SaclaMPCCD(FormatMultiImageLazy, FormatHDF5, FormatStill):
     """
     Class to handle multi-event HDF5 files from MPCCD
     preprocessed by Cheetah SFX pipeline at SACLA.

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -120,6 +120,18 @@ class FormatMultiImage(Format):
         Factory method to create an imageset
 
         """
+
+        def _add_static_mask_to_iset(format_instance, iset):
+            if format_instance is not None:
+                static_mask = format_instance.get_static_mask()
+                if static_mask is not None:
+                    if not iset.external_lookup.mask.data.empty():
+                        for m1, m2 in zip(static_mask, iset.external_lookup.mask.data):
+                            m1 &= m2.data()
+                        iset.external_lookup.mask.data = ImageBool(static_mask)
+                    else:
+                        iset.external_lookup.mask.data = ImageBool(static_mask)
+
         if isinstance(filenames, str):
             filenames = [filenames]
         elif len(filenames) > 1:
@@ -219,6 +231,7 @@ class FormatMultiImage(Format):
                     ),
                     indices=single_file_indices,
                 )
+                _add_static_mask_to_iset(format_instance, iset)
                 return iset
             # Create the imageset
             iset = ImageSet(
@@ -310,14 +323,6 @@ class FormatMultiImage(Format):
                 indices=single_file_indices,
             )
 
-        if format_instance is not None:
-            static_mask = format_instance.get_static_mask()
-            if static_mask is not None:
-                if not iset.external_lookup.mask.data.empty():
-                    for m1, m2 in zip(static_mask, iset.external_lookup.mask.data):
-                        m1 &= m2.data()
-                    iset.external_lookup.mask.data = ImageBool(static_mask)
-                else:
-                    iset.external_lookup.mask.data = ImageBool(static_mask)
+        _add_static_mask_to_iset(format_instance, iset)
 
         return iset


### PR DESCRIPTION
- Add FormatMultiImageLazy as a mixin

- Bugfix in FormatMultiImage: If we're creating an ImageSetLazy, we still
  need to get the static mask from the format class and add it to the
  imageset.

Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>