### PR TITLE
Add a pytest launcher to dxtbx

### DIFF
--- a/command_line/pytest_launcher.py
+++ b/command_line/pytest_launcher.py
@@ -1,0 +1,9 @@
+# LIBTBX_SET_DISPATCHER_NAME pytest
+import sys
+
+import pytest
+
+# modify sys.argv so the command line help shows the right executable name
+sys.argv[0] = "pytest"
+
+sys.exit(pytest.main())


### PR DESCRIPTION
effectively moving it downstream from libtbx (cctbx/cctbx_project#540) until we can fix the underlying issue.

This needs to be merged at roughly the same time. Developers may encounter an error such as
```
RuntimeError: Multiple sources for dispatcher:
  target file:
    "build/bin/pytest"
  source files:
    "modules/cctbx_project/libtbx/command_line/pytest_launcher.py"
   =relocatable_path(anchor="build", relocatable="../modules/cctbx_project/libtbx/command_line/pytest_launcher.py")
    "/scratch/wra62962/files/dials/modules/dxtbx/command_line/pytest_launcher.py"
   =relocatable_path(anchor="build", relocatable="../modules/dxtbx/command_line/pytest_launcher.py")
```
on reconfiguring. This means that the `cctbx_project` repository is out of date and needs updating.