### PR TITLE
Hardlink fix for NeXus files

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -1426,7 +1426,7 @@ def detectorgroupdatafactory(obj, instrument):
             continue
 
         # Map NXdetector names to list of datasets
-        dataset_name = os.path.basename(dataset.name)
+        dataset_name = key
         found_it = False
         for detector in instrument.detectors:
             if dataset_name in detector.handle:


### PR DESCRIPTION
Using dataset.name doesn't work here if using hardlinks, as dataset.name will be the name of the field in the linked to file, instead of the name of the field in the master file.