### PR TITLE
Add warning if h5py is imported before dxtbx

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,13 +16,17 @@ if sys.version_info.major == 2:
         UserWarning,
     )
 
+logger = logging.getLogger("dxtbx")
+logger.addHandler(logging.NullHandler())
+
+if "h5py" in sys.modules:
+    logging.warning("Importing h5py before dxtbx may cause issues reading Eiger data")
+
 # Set up the plugin path for HDF5 to pick up compression plugins.
 plugin_path = libtbx.env.under_base(os.path.join("lib", "plugins"))
 os.environ["HDF5_PLUGIN_PATH"] = (
     plugin_path + os.pathsep + os.getenv("HDF5_PLUGIN_PATH", "")
 )
-
-logging.getLogger("dxtbx").addHandler(logging.NullHandler())
 
 
 class IncorrectFormatError(RuntimeError):


### PR DESCRIPTION
Importing h5py before dxtbx can lead to unobvious errors when reading Eiger data, related to hd5f plugin paths.

I'm not sure whether `logger.warning` or `warnings.warn` is more appropriate here.