### PR TITLE
Increase scan tolerance

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -1787,7 +1787,7 @@ class GoniometerDiff:
 class ScanDiff:
     """A class to provide scan comparison"""
 
-    def __init__(self, scan_tolerance=1e-6):
+    def __init__(self, scan_tolerance=0.03):
         self.scan_tolerance = scan_tolerance
 
     def __call__(self, a, b):

--- a/datablock.py
+++ b/datablock.py
@@ -716,7 +716,7 @@ def _merge_scans(records, scan_tolerance=None):
 
     Args:
         records:        Records to merge
-        scan_tolerance: Percentage of oscillation range to tolerate
+        scan_tolerance: Fraction of oscillation range to tolerate
                         when merging scan records
 
     Returns:

--- a/model/boost_python/scan.cc
+++ b/model/boost_python/scan.cc
@@ -459,7 +459,7 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def(self >= self)
       .def(self += self)
       .def(self + self)
-      .def("append", &Scan::append, (arg("rhs"), arg("scan_tolerance") = 0.01))
+      .def("append", &Scan::append, (arg("rhs"), arg("scan_tolerance") = 0.03))
       .def("__len__", &Scan::get_num_images)
       .def("__str__", &scan_to_string)
       .def("swap", &scan_swap)


### PR DESCRIPTION
The scan tolerance is currently set to 1% of the image width. This is fine for X-ray beamlines, but the rotation stages of electron microscopes are generally less accurate. As a result, images that should form a single sweep are sometimes split into two or more.  Out of 16 datasets recently collected at eBIC, one is split into two sweeps with a 1% tolerance. Homing in on the critical value shows that 1.87% tolerance is sufficient to import this as a single sweep.
```
$ dials.import ../../data/day3/Xstal12/*[0-9].mrc tolerance.scan.oscillation=0.0186
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
DIALS 3.dev.328-g92e7e3bf3
dxtbx Internal Error: /home/fcx32934/sw/cctbx/modules/dxtbx/model/scan.h(358): DXTBX_ASSERT(std::min(diff_2pi, diff_abs) < eps * get_num_images()) failure.
The following parameters have been modified:

input {
  experiments = <image files>
  tolerance {
    scan {
      oscillation = 0.0186
    }
  }
}

--------------------------------------------------------------------------------
  format: <class 'dxtbx_custom.FormatMRC.FormatMRCimages'>
  num images: 52
  sequences:
    still:    0
    sweep:    2
  num stills: 0
--------------------------------------------------------------------------------
```
cf.
```
$ dials.import ../../data/day3/Xstal12/*[0-9].mrc tolerance.scan.oscillation=0.0187
DIALS (2018) Acta Cryst. D74, 85-97. https://doi.org/10.1107/S2059798317017235
DIALS 3.dev.328-g92e7e3bf3
The following parameters have been modified:

input {
  experiments = <image files>
  tolerance {
    scan {
      oscillation = 0.0187
    }
  }
}

--------------------------------------------------------------------------------
  format: <class 'dxtbx_custom.FormatMRC.FormatMRCimages'>
  num images: 52
  sequences:
    still:    0
    sweep:    1
  num stills: 0
--------------------------------------------------------------------------------
```
This PR increases the scan tolerance to 3% of the image width, in an attempt to give sufficient headroom to accommodate datasets collected with worse rotation stages.