### PR TITLE
Correct update warning message

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,7 +34,7 @@ if os.path.exists(_legacy_plugin_path) and not os.path.exists(_new_plugin_path):
     _hdf5_plugin_path = _legacy_plugin_path
     warnings.warn(
         "You are using an outdated version of the hdf5-external-filter-plugins package.\n"
-        "Please update your environment using 'conda install hdf5-external-filter-plugins'",
+        "Please update your environment using 'conda update hdf5-external-filter-plugins'",
         UserWarning,
     )
 else:

--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,2 @@
+Correct a warning message about using an outdated version of the ``hdf5-external-filter-plugins`` package.
+The suggested command to fix the warning is now given as ``conda update hdf5-external-filter-plugins``.


### PR DESCRIPTION
Correct a warning message about using an outdated version of the `hdf5-external-filter-plugins` package.
The suggested command to fix the warning is now given as `conda update hdf5-external-filter-plugins`.

`s/install/update/`