### PR TITLE
Remove code that cannot be hit

### DIFF
--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -297,10 +297,6 @@ class FormatMultiImage(Format):
                 goniometer = format_instance.get_goniometer()
             if scan is None:
                 scan = format_instance.get_scan()
-                if scan is not None:
-                    for f in filenames[1:]:
-                        format_instance = cls(f, **format_kwargs)
-                        scan += format_instance.get_scan()
 
             # Create the masker
             if format_instance is not None:


### PR DESCRIPTION
We [assert above](https://github.com/dials/dxtbx/blob/f45d1e4a0ec1f2b0382b56878573fb8685dd4894/format/FormatMultiImage.py#L159) that `len(filenames) == 1`, so there is literally no point in looping over `filenames[1:]`

