### PR TITLE
Fix missing SENSOR_THICKNESS= for EIGER

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Fix for missing SENSOR_THICKNESS= in XDS.INP generated for EIGER datasets introduced in 3.3.1

--- a/serialize/xds.py
+++ b/serialize/xds.py
@@ -307,7 +307,7 @@ class to_xds(object):
             % (detector, trusted[0] + 1, trusted[1])
         )
 
-        if detector == "PILATUS":
+        if detector in ("PILATUS", "EIGER"):
             result.append(
                 "SENSOR_THICKNESS= %.3f" % self.get_detector()[0].get_thickness()
             )

--- a/tests/serialize/test_xds.py
+++ b/tests/serialize/test_xds.py
@@ -136,3 +136,4 @@ def test_vmxi_thaumatin(dials_data):
     to_xds = xds.to_xds(expts[0].imageset)
     s = to_xds.XDS_INP()
     assert "DETECTOR=EIGER" in s
+    assert "SENSOR_THICKNESS= 0.450" in s


### PR DESCRIPTION
Fix for missing `SENSOR_THICKNESS=` in XDS.INP generated for EIGER datasets introduced in 3.3.1 (#292)