### PR TITLE
DIALS 3.3.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.3.3 (2021-02-15)
+========================
+
+Bugfixes
+--------
+
+- Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1 (`#296 <https://github.com/cctbx/dxtbx/issues/296>`_)
+
+
 DIALS 3.3.2 (2021-02-01)
 ========================
 

--- a/newsfragments/296.bugfix
+++ b/newsfragments/296.bugfix
@@ -1,0 +1,1 @@
+Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1

--- a/newsfragments/296.bugfix
+++ b/newsfragments/296.bugfix
@@ -1,1 +1,0 @@
-Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1

--- a/serialize/xds.py
+++ b/serialize/xds.py
@@ -307,7 +307,7 @@ class to_xds(object):
             % (detector, trusted[0] + 1, trusted[1])
         )
 
-        if detector == "PILATUS":
+        if detector in ("PILATUS", "EIGER"):
             result.append(
                 "SENSOR_THICKNESS= %.3f" % self.get_detector()[0].get_thickness()
             )

--- a/tests/serialize/test_xds.py
+++ b/tests/serialize/test_xds.py
@@ -136,3 +136,4 @@ def test_vmxi_thaumatin(dials_data):
     to_xds = xds.to_xds(expts[0].imageset)
     s = to_xds.XDS_INP()
     assert "DETECTOR=EIGER" in s
+    assert "SENSOR_THICKNESS= 0.450" in s


### PR DESCRIPTION
- Fix for missing ``SENSOR_THICKNESS=`` in XDS.INP generated for EIGER datasets introduced in 3.3.1 (cctbx/dxtbx#296)