### PR TITLE
Tidy up dlsnxs2cbf

### DIFF
--- a/util/dlsnxs2cbf.py
+++ b/util/dlsnxs2cbf.py
@@ -31,18 +31,6 @@ def get_mask(nfast, nslow):
     return mask
 
 
-def depends_on(f):
-    def finder(thing, path):
-        if hasattr(thing, "keys"):
-            for k in thing:
-                try:
-                    finder(thing[k], path="%s/%s" % (path, k))
-                except (IOError, TypeError, ValueError, KeyError):
-                    pass
-
-    finder(f, path="")
-
-
 def get_distance_in_mm(f):
     try:
         D = f["/entry/instrument/detector_distance"]
@@ -132,65 +120,63 @@ _array_data.header_contents
 
 
 def make_cbf(in_name, template):
-    f = h5py.File(in_name, "r")
-    depends_on(f)
+    with h5py.File(in_name, "r") as f:
+        mask = None
 
-    mask = None
+        start_tag = binascii.unhexlify("0c1a04d5")
 
-    start_tag = binascii.unhexlify("0c1a04d5")
+        for j in range(len(f["/entry/sample/transformations/omega"][()])):
+            block = 1 + (j // 1000)
+            i = j % 1000
+            header = compute_cbf_header(f, j)
+            depth, height, width = f["/entry/data/data_%06d" % block].shape
 
-    for j in range(len(f["/entry/sample/transformations/omega"][()])):
-        block = 1 + (j // 1000)
-        i = j % 1000
-        header = compute_cbf_header(f, j)
-        depth, height, width = f["/entry/data/data_%06d" % block].shape
+            data = flex.int(np.int32(f["/entry/data/data_%06d" % block][i]))
+            good = data.as_1d() < 65535
+            data.as_1d().set_selected(~good, -2)
 
-        data = flex.int(np.int32(f["/entry/data/data_%06d" % block][i]))
-        good = data.as_1d() < 65535
-        data.as_1d().set_selected(~good, -2)
+            # set the tile join regions to -1 - MOSFLM cares about this apparently
+            if mask is None:
+                mask = get_mask(width, height)
+            data.as_1d().set_selected(mask.as_1d(), -1)
 
-        # set the tile join regions to -1 - MOSFLM cares about this apparently
-        if mask is None:
-            mask = get_mask(width, height)
-        data.as_1d().set_selected(mask.as_1d(), -1)
+            compressed = compress(data)
 
-        compressed = compress(data)
+            mime = """
 
-        mime = """
+    _array_data.data
+    ;
+    --CIF-BINARY-FORMAT-SECTION--
+    Content-Type: application/octet-stream;
+         conversions="x-CBF_BYTE_OFFSET"
+    Content-Transfer-Encoding: BINARY
+    X-Binary-Size: %d
+    X-Binary-ID: 1
+    X-Binary-Element-Type: "signed 32-bit integer"
+    X-Binary-Element-Byte-Order: LITTLE_ENDIAN
+    X-Binary-Number-of-Elements: %d
+    X-Binary-Size-Fastest-Dimension: %d
+    X-Binary-Size-Second-Dimension: %d
+    X-Binary-Size-Padding: 4095
 
-_array_data.data
-;
---CIF-BINARY-FORMAT-SECTION--
-Content-Type: application/octet-stream;
-     conversions="x-CBF_BYTE_OFFSET"
-Content-Transfer-Encoding: BINARY
-X-Binary-Size: %d
-X-Binary-ID: 1
-X-Binary-Element-Type: "signed 32-bit integer"
-X-Binary-Element-Byte-Order: LITTLE_ENDIAN
-X-Binary-Number-of-Elements: %d
-X-Binary-Size-Fastest-Dimension: %d
-X-Binary-Size-Second-Dimension: %d
-X-Binary-Size-Padding: 4095
+    """ % (
+                len(compressed),
+                data.size(),
+                data.focus()[1],
+                data.focus()[0],
+            )
 
-""" % (
-            len(compressed),
-            data.size(),
-            data.focus()[1],
-            data.focus()[0],
-        )
+            padding = (
+                bytearray(4095)
+                + b"""--CIF-BINARY-FORMAT-SECTION----
+    ;"""
+            )
 
-        padding = (
-            bytearray(4095)
-            + b"""--CIF-BINARY-FORMAT-SECTION----
-;"""
-        )
-
-        with open(template % (j + 1), "wb") as fout:
-            print(template % (j + 1))
-            fout.write(("".join(header) + mime).replace("\n", "\r\n").encode("latin-1"))
-            fout.write(start_tag)
-            fout.write(compressed)
-            fout.write(padding)
-
-    f.close()
+            with open(template % (j + 1), "wb") as fout:
+                print(template % (j + 1))
+                fout.write(
+                    ("".join(header) + mime).replace("\n", "\r\n").encode("latin-1")
+                )
+                fout.write(start_tag)
+                fout.write(compressed)
+                fout.write(padding)


### PR DESCRIPTION
`dxtbx.dlsnxs2cbf` seems to have some idiosyncratic code that could do with tidying up.  In particular, we ought to be using a context manager for file input as well as output, and the function `depends_on` is either a no-op (quite probable) or it is probing implicitly for some exception that that it does not handle, in which case that behaviour ought to be documented.