### PR TITLE
Include PxMmStrategy in Panel equality operator

### DIFF
--- a/model/boost_python/panel.cc
+++ b/model/boost_python/panel.cc
@@ -534,6 +534,8 @@ namespace dxtbx { namespace model { namespace boost_python {
            return_value_policy<manage_new_object>())
       .staticmethod("from_dict")
       .def("is_", &panel_is)
+      .def("__eq__", &Panel::operator==)
+      .def("__ne__", &Panel::operator!=)
       .def_pickle(PanelPickleSuite());
   }
 

--- a/model/boost_python/pixel_to_millimeter.cc
+++ b/model/boost_python/pixel_to_millimeter.cc
@@ -87,7 +87,9 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("to_millimeter", to_millimeter, (arg("panel"), arg("xy")))
       .def("to_pixel", &PxMmStrategy::to_pixel, (arg("panel"), arg("xy")))
       .def("name", &PxMmStrategy::name)
-      .def("__str__", &PxMmStrategy::strategy_name);
+      .def("__str__", &PxMmStrategy::strategy_name)
+      .def("__eq__", &PxMmStrategy::operator==)
+      .def("__ne__", &PxMmStrategy::operator!=);
 
     class_<SimplePxMmStrategy, bases<PxMmStrategy> >("SimplePxMmStrategy")
       .def_pickle(PxMmStrategyPickleSuite());
@@ -97,6 +99,8 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def(init<double, double>((arg("mu"), arg("t0"))))
       .def("mu", &ParallaxCorrectedPxMmStrategy::mu)
       .def("t0", &ParallaxCorrectedPxMmStrategy::t0)
+      .def("__eq__", &ParallaxCorrectedPxMmStrategy::operator==)
+      .def("__ne__", &ParallaxCorrectedPxMmStrategy::operator!=)
       .def_pickle(ParallaxCorrectedPxMmStrategyPickleSuite());
 
     class_<OffsetPxMmStrategy, bases<PxMmStrategy> >("OffsetPxMmStrategy", no_init)

--- a/model/panel.h
+++ b/model/panel.h
@@ -400,7 +400,7 @@ namespace dxtbx { namespace model {
 
     /** @returns True/False this is the same as the other */
     bool operator==(const Panel &other) const {
-      return VirtualPanel::operator==(other) && convert_coord_ == other.convert_coord_;
+      return PanelData::operator==(other) && *convert_coord_ == *other.convert_coord_;
     }
 
     /** @returns True/False this is not the same as the other */

--- a/model/panel.h
+++ b/model/panel.h
@@ -398,6 +398,16 @@ namespace dxtbx { namespace model {
 
     friend std::ostream &operator<<(std::ostream &os, const Panel &p);
 
+    /** @returns True/False this is the same as the other */
+    bool operator==(const Panel &other) const {
+      return VirtualPanel::operator==(other) && convert_coord_ == other.convert_coord_;
+    }
+
+    /** @returns True/False this is not the same as the other */
+    bool operator!=(const Panel &other) const {
+      return !(*this == other);
+    }
+
   protected:
     double gain_;
     double pedestal_;

--- a/model/pixel_to_millimeter.h
+++ b/model/pixel_to_millimeter.h
@@ -62,6 +62,17 @@ namespace dxtbx { namespace model {
       throw DXTBX_ERROR("Overload me");
       return std::string();
     }
+
+    /** @returns True/False this is the same as the other */
+    bool operator==(const PxMmStrategy &other) const {
+      return strategy_name() == other.strategy_name();
+    }
+
+    /** @returns True/False this is not the same as the other */
+    bool operator!=(const PxMmStrategy &other) const {
+      return !(*this == other);
+    }
+
   };
 
   /**
@@ -201,6 +212,16 @@ namespace dxtbx { namespace model {
 
     std::string strategy_name() const {
       return std::string("ParallaxCorrectedPxMmStrategy\n") + mu_t0();
+    }
+
+    /** @returns True/False this is the same as the other */
+    bool operator==(const ParallaxCorrectedPxMmStrategy &other) const {
+      return SimplePxMmStrategy::operator==(other) && mu_ == other.mu_ && t0_ == other.t0_;
+    }
+
+    /** @returns True/False this is not the same as the other */
+    bool operator!=(const ParallaxCorrectedPxMmStrategy &other) const {
+      return !(*this == other);
     }
 
   protected:

--- a/newsfragments/XXX.feature
+++ b/newsfragments/XXX.feature
@@ -1,0 +1,1 @@
+Include test for equality of ``PxMmStrategy`` in ``Panel`` equality operator.

--- a/tests/model/test_detector.py
+++ b/tests/model/test_detector.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import copy
 import random
 from builtins import range
 
@@ -268,6 +269,15 @@ def test_equality():
     # Equality operator on detector objects must identify identical detectors
     detector_moved_copy = create_detector(offset=100)
     assert detector_moved == detector_moved_copy
+
+
+def test_panel_equality():
+    panel = create_detector(offset=0)[0]
+    panel2 = copy.deepcopy(panel)
+    assert panel == panel2
+
+    panel2.set_px_mm_strategy(ParallaxCorrectedPxMmStrategy(1, 1))
+    assert panel != panel2
 
 
 def test_project_2d():

--- a/tests/model/test_detector.py
+++ b/tests/model/test_detector.py
@@ -279,6 +279,9 @@ def test_panel_equality():
     panel2.set_px_mm_strategy(ParallaxCorrectedPxMmStrategy(1, 1))
     assert panel != panel2
 
+    panel.set_px_mm_strategy(ParallaxCorrectedPxMmStrategy(1, 1))
+    assert panel == panel2
+
 
 def test_project_2d():
     # The function project_2d should give the same results even if the

--- a/tests/model/test_pixel_to_millimeter.py
+++ b/tests/model/test_pixel_to_millimeter.py
@@ -141,11 +141,13 @@ def test_offset_px_mm_strategy():
 
     d = p.to_dict()
 
+    # Panel.from_dict sets the strategy to ParallaxCorrectedPxMmStrategy rather than
+    # OffsetParallaxCorrectedPxMmStrategy as the offsets aren't currently serialized
     pnew = Panel.from_dict(d)
-    assert pnew == p
+    assert pnew != p
 
     pnew = pickle.loads(pickle.dumps(pnew))
-    assert pnew == p
+    assert pnew != p
 
 
 def test_px_mm_strategy_equality():

--- a/tests/model/test_pixel_to_millimeter.py
+++ b/tests/model/test_pixel_to_millimeter.py
@@ -16,8 +16,10 @@ from scitbx.array_family import flex
 import dxtbx
 from dxtbx.model import (
     OffsetParallaxCorrectedPxMmStrategy,
+    OffsetPxMmStrategy,
     Panel,
     ParallaxCorrectedPxMmStrategy,
+    SimplePxMmStrategy,
 )
 from dxtbx.model.beam import BeamFactory
 from dxtbx.model.detector import DetectorFactory
@@ -144,3 +146,36 @@ def test_offset_px_mm_strategy():
 
     pnew = pickle.loads(pickle.dumps(pnew))
     assert pnew == p
+
+
+def test_px_mm_strategy_equality():
+    simple = SimplePxMmStrategy()
+    assert simple == SimplePxMmStrategy()
+
+    parallax_corrected = ParallaxCorrectedPxMmStrategy(1, 1)
+    assert parallax_corrected == ParallaxCorrectedPxMmStrategy(1, 1)
+    assert parallax_corrected != ParallaxCorrectedPxMmStrategy(1, 2)
+    assert parallax_corrected != ParallaxCorrectedPxMmStrategy(2, 1)
+    assert parallax_corrected != simple
+
+    dx = flex.double(flex.grid(10, 10), 1)
+    dy = flex.double(flex.grid(10, 10), 1)
+
+    offset = OffsetPxMmStrategy(dx, dy)
+    assert offset == OffsetPxMmStrategy(dx, dy)
+    assert offset != simple
+    assert offset != parallax_corrected
+
+    offset_parallax_corrected = OffsetParallaxCorrectedPxMmStrategy(1, 1, dx, dy)
+    assert offset_parallax_corrected == OffsetParallaxCorrectedPxMmStrategy(
+        1, 1, dx, dy
+    )
+    assert offset_parallax_corrected != OffsetParallaxCorrectedPxMmStrategy(
+        1, 2, dx, dy
+    )
+    assert offset_parallax_corrected != OffsetParallaxCorrectedPxMmStrategy(
+        2, 1, dx, dy
+    )
+    assert offset_parallax_corrected != simple
+    assert offset_parallax_corrected != parallax_corrected
+    assert offset_parallax_corrected != offset


### PR DESCRIPTION
Previously two panels with different `PxMmStrategy`s could be treated as equal. This pull request adds equality operators for the various types of `PxMmStrategy` and a test for equality of `PxMmStrategy` in the `Panel` equality operator.