### PR TITLE
limit boost version to below 1.75

### DIFF
--- a/.azure-pipelines/ci-conda-env.txt
+++ b/.azure-pipelines/ci-conda-env.txt
@@ -1,5 +1,5 @@
 conda-forge::boost
-conda-forge::boost-cpp
+conda-forge::boost-cpp<1.75
 conda-forge::bzip2
 conda-forge::c-compiler
 conda-forge::conda

--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,1 @@
+Limit boost to <1.75 on dxtbx Azure builds


### PR DESCRIPTION
1.75 needs a C++14 compiler and cctbx presumably can't handle that.

This only affects dxtbx Azure builds, and has nothing to do with DIALS bootstrap.