### PR TITLE
DIALS 3.5.1

### DIFF
--- a/format/FormatNexusEigerDLS16MI03.py
+++ b/format/FormatNexusEigerDLS16MI03.py
@@ -24,9 +24,7 @@ class FormatNexusEigerDLS16MI03(FormatNexusEigerDLS16M):
                 timestamp = get_pilatus_timestamp(
                     h5str(fh["/entry/start_time"][()]).rstrip("Z")
                 )
-                return timestamp > calendar.timegm(
-                    (2021, 4, 22, 0, 0, 0)
-                ) and timestamp < calendar.timegm((2021, 6, 1, 0, 0, 0))
+                return timestamp > calendar.timegm((2021, 4, 22, 0, 0, 0))
 
     def _start(self):
         super()._start()

--- a/model/scan.py
+++ b/model/scan.py
@@ -154,6 +154,13 @@ class ScanFactory:
         index = scan_helper_image_files.image_to_index(os.path.split(filename)[-1])
         if epoch is None:
             epoch = 0.0
+
+        # if the oscillation width is negative at this stage it is almost
+        # certainly an artefact of the omega end being 0 when the omega start
+        # angle was ~ 360 so it would be ~ -360 - see dxtbx#378
+        if osc_width < -180:
+            osc_width += 360
+
         return ScanFactory.make_scan(
             (index, index), exposure_times, (osc_start, osc_width), {index: epoch}
         )

--- a/newsfragments/370.bugfix
+++ b/newsfragments/370.bugfix
@@ -1,0 +1,1 @@
+Extend duration of bad module mask for Diamond I03 EIGER 2XE 16M detector indefinitely. This will be updated in a future release.

--- a/newsfragments/379.bugfix
+++ b/newsfragments/379.bugfix
@@ -1,0 +1,1 @@
+Handle scan data which wraps through 0° instead of >=360°

--- a/tests/model/test_scan.py
+++ b/tests/model/test_scan.py
@@ -3,3 +3,19 @@ import dxtbx.model
 
 def test_scan_to_string_does_not_crash_on_empty_scan():
     print(dxtbx.model.Scan())
+
+
+def test_scan_wrap_around_zero():
+    filenames = [f"foobar_{n:03d}.cbf" for n in range(350, 370)]
+    starts = [r % 360 for r in range(350, 370)]
+    ends = [(r + 1) % 360 for r in range(350, 370)]
+    scans = [
+        dxtbx.model.scan.ScanFactory.single_file(f, [0.1], s, e - s, 0)
+        for f, s, e in zip(filenames, starts, ends)
+    ]
+    s0 = scans[0]
+    for s in scans[1:]:
+        assert s.get_oscillation()[1] == 1
+        s0 += s
+    assert s0.get_oscillation() == (350, 1)
+    assert s0.get_image_range() == (350, 369)


### PR DESCRIPTION
Bugfixes
--------

- Extend duration of bad module mask for Diamond I03 EIGER 2XE 16M detector indefinitely. This will be updated in a future release. (cctbx/dxtbx#370)
- Handle scan data which wraps through 0° instead of >=360° (cctbx/dxtbx#379)