### PR TITLE
Fix azure build by pinning cctbx_project

### DIFF
--- a/.azure-pipelines/bootstrap.py
+++ b/.azure-pipelines/bootstrap.py
@@ -671,12 +671,6 @@ def update_sources(options):
             "dials/cbflib",
         )
     }
-    repositories["cctbx_project"] = {
-        "base-repository": "cctbx/cctbx_project",
-        "effective-repository": "dials/cctbx",
-        "branch-remote": "master",
-        "branch-local": "stable",
-    }
     repositories["dxtbx"] = {
         "base-repository": "cctbx/dxtbx",
         "branch-local": "main",

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -16,7 +16,13 @@ steps:
 # Download other source repositories
 - bash: |
     set -eux
-    python3 modules/dxtbx/.azure-pipelines/bootstrap.py update
+
+    # Extract the version of cctbx-base from the conda environment file
+    [[ "$(cat ../modules/dxtbx/.azure-pipelines/ci-conda-env.txt)" =~ cctbx-base==([^:space:]+) ]]
+    cctbx_version="$("${BASH_REMATCH[1]}" | xargs)"
+    echo "Using cctbx conda release ${cctbx_version}"
+
+    python3 modules/dxtbx/.azure-pipelines/bootstrap.py update --branch cctbx_project@"v${cctbx_version}"
   displayName: Repository checkout
   workingDirectory: $(Pipeline.Workspace)
 

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Fix Azure builds by pinning cctbx_project


### PR DESCRIPTION
Current SEGV is occuring due to a mismatch in the version used for compiling dxtbx (checked out into `modules/`) and the version used for python importing (from `lib/python3.X/site-packages/scitbx` in the conda environment).

This reads the cctbx-base version from the package list so that `bootstrap.py update` can be run before creating the conda environment, and fixes the branch to that.

Fixes https://github.com/cctbx/dxtbx/issues/383 and fixes https://github.com/cctbx/dxtbx/issues/383 (hopefully!)