### PR TITLE
DIALS 3.5.2

### DIFF
--- a/format/FormatNexusEigerDLS16MI03.py
+++ b/format/FormatNexusEigerDLS16MI03.py
@@ -24,7 +24,9 @@ class FormatNexusEigerDLS16MI03(FormatNexusEigerDLS16M):
                 timestamp = get_pilatus_timestamp(
                     h5str(fh["/entry/start_time"][()]).rstrip("Z")
                 )
-                return timestamp > calendar.timegm((2021, 4, 22, 0, 0, 0))
+                return timestamp > calendar.timegm(
+                    (2021, 4, 22, 0, 0, 0)
+                ) and timestamp <= calendar.timegm((2021, 6, 22, 0, 0, 0))
 
     def _start(self):
         super()._start()

--- a/newsfragments/385.bugfix
+++ b/newsfragments/385.bugfix
@@ -1,0 +1,1 @@
+End the I03 "bad mask" duration, since it is now masked at the file level.

--- a/newsfragments/387.bugfix
+++ b/newsfragments/387.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.dlsnxs2cbf``: Handle missing chi/phi axis entries.

--- a/util/dlsnxs2cbf.py
+++ b/util/dlsnxs2cbf.py
@@ -81,8 +81,8 @@ def compute_cbf_header(f, nn=0):
     timestamp = f["/entry/start_time"][()].decode()[:19]
     omega = f["/entry/sample/transformations/omega"][()]
     omega_increment = f["/entry/sample/transformations/omega_increment_set"][()]
-    chi = f["/entry/sample/transformations/chi"][()]
-    phi = f["/entry/sample/transformations/phi"][()]
+    chi_key = "/entry/sample/transformations/chi"
+    phi_key = "/entry/sample/transformations/phi"
 
     if "/entry/instrument/detector/beam_centre_x" in f:
         Bx = instrument["detector/beam_centre_x"][()]
@@ -124,12 +124,14 @@ _array_data.header_contents
     result.append("# Polarization 0.990")
     result.append("# Alpha 0.0000 deg.")
     result.append("# Kappa 0.0000 deg.")
-    result.append("# Phi %.4f deg." % phi)
-    result.append("# Phi_increment 0.0000 deg.")
+    if phi_key in f:
+        result.append(f"# Phi {np.squeeze(f[phi_key][()]):.4f} deg.")
+        result.append("# Phi_increment 0.0000 deg.")
     result.append("# Omega %.4f deg." % omega[nn])
     result.append("# Omega_increment %.4f deg." % omega_increment[nn])
-    result.append("# Chi %.4f deg." % chi)
-    result.append("# Chi_increment 0.0000 deg.")
+    if chi_key in f:
+        result.append(f"# Chi {np.squeeze(f[chi_key][()]):.4f} deg.")
+        result.append("# Chi_increment 0.0000 deg.")
     result.append("# Oscillation_axis X.CW")
     result.append("# N_oscillations 1")
     result.append(";")


### PR DESCRIPTION
Bugfixes
--------

- End the I03 "bad mask" duration, since it is now masked at the file level. (cctbx/dxtbx#385)
- ``dxtbx.dlsnxs2cbf``: Handle missing chi/phi axis entries. (cctbx/dxtbx#387)