### PR TITLE
Fix the catch-value compiler warning.

### DIFF
--- a/src/dxtbx/masking/masking.h
+++ b/src/dxtbx/masking/masking.h
@@ -199,7 +199,7 @@ namespace dxtbx { namespace masking {
           vec2<double> px(i + 0.5, j + 0.5);
           try {
             resolution_(j, i) = panel.get_resolution_at_pixel(s0, px);
-          } catch (dxtbx::error) {
+          } catch (dxtbx::error const&) {
             // Known failure: resolution at beam center is undefined
             resolution_(j, i) = 0.0;
           }

--- a/src/dxtbx/model/detector.h
+++ b/src/dxtbx/model/detector.h
@@ -654,7 +654,7 @@ namespace dxtbx { namespace model {
         if (size() == 1) {
           return (*this)[0].get_max_resolution_ellipse(s0);
         }
-      } catch (dxtbx::error) {
+      } catch (dxtbx::error const&) {
         // do nothing
       }
 
@@ -750,7 +750,7 @@ namespace dxtbx { namespace model {
             found_panel = (int)i;
             break;
           }
-        } catch (dxtbx::error) {
+        } catch (dxtbx::error const&) {
           // pass
         }
       }

--- a/src/dxtbx/model/virtual_panel.h
+++ b/src/dxtbx/model/virtual_panel.h
@@ -314,7 +314,7 @@ namespace dxtbx { namespace model {
       // Update the D matrix
       try {
         D_ = d_.inverse();
-      } catch (scitbx::error) {
+      } catch (scitbx::error const&) {
         D_ = boost::none;
       }
 
@@ -323,7 +323,7 @@ namespace dxtbx { namespace model {
       distance_ = get_origin() * get_normal();
       try {
         normal_origin_ = get_bidirectional_ray_intersection(get_normal());
-      } catch (dxtbx::error) {
+      } catch (dxtbx::error const&) {
         normal_origin_ = vec2<double>(0, 0);
       }
     }


### PR DESCRIPTION
Catching a polymorphic type by value raises gcc 8.3.0 warning.
Use catch(thing const&) instead.