### PR TITLE
Fix the 'int-in-bool-context' compiler warning.

### DIFF
--- a/src/dxtbx/masking/goniometer_shadow_masking.h
+++ b/src/dxtbx/masking/goniometer_shadow_masking.h
@@ -145,7 +145,7 @@ namespace dxtbx { namespace masking {
         // if the invalidity is only due to lack of closing points and/or wrongly
         // oriented rings, then bg::correct can fix it
         bool could_be_fixed = (failure == boost::geometry::failure_not_closed
-                               || boost::geometry::failure_wrong_orientation);
+                               || failure == boost::geometry::failure_wrong_orientation);
         if (!valid) {
           if (could_be_fixed) {
             boost::geometry::correct(poly);


### PR DESCRIPTION
Using an enum constant in a boolean context does not make sense in the
program and it generates a compiler warning in gcc.  This code change is
an educated guess as to the originally intended meaning.