### PR TITLE
Avoid failing with traceback when template is given no `#` tokens

### DIFF
--- a/src/dxtbx/model/experiment_list.py
+++ b/src/dxtbx/model/experiment_list.py
@@ -846,7 +846,10 @@ class ExperimentListFactory:
                     f"Image file {filenames[0]} appears to be a '{type(format_class).__name__}', but this is an abstract Format"
                 )
             else:
-                index = slice(*template_string_number_index(template))
+                if "#" in template:
+                    index = slice(*template_string_number_index(template))
+                else:  # there is just one file
+                    index = 0
                 image_range = kwargs.get("image_range")
                 if image_range:
                     first, last = image_range

--- a/src/dxtbx/sequence_filenames.py
+++ b/src/dxtbx/sequence_filenames.py
@@ -179,9 +179,12 @@ def replace_template_format_with_hash(match):
 
 def template_string_to_glob_expr(template):
     """Convert the template to a glob expression."""
-    pfx = template.split("#")[0]
-    sfx = template.split("#")[-1]
-    return "%s%s%s" % (pfx, "[0-9]" * template.count("#"), sfx)
+    if "#" in template:
+        pfx = template.split("#")[0]
+        sfx = template.split("#")[-1]
+        return "%s%s%s" % (pfx, "[0-9]" * template.count("#"), sfx)
+    else:
+        return "%s" % (template)
 
 
 def template_string_number_index(template):


### PR DESCRIPTION
Deal with `dials.import template=path/to/file`.