### PR TITLE
Bugfix for empty beams in XTC streams

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Check for empty beams in XTC streams

--- a/src/dxtbx/format/FormatXTC.py
+++ b/src/dxtbx/format/FormatXTC.py
@@ -289,7 +289,8 @@ class FormatXTC(FormatMultiImageLazy, FormatStill, Format):
             if (
                 evttime.tm_year == 2020 and evttime.tm_mon >= 7
             ) or evttime.tm_year > 2020:
-                self._beam_cache.set_polarization_normal((1, 0, 0))
+                if self._beam_cache is not None:
+                    self._beam_cache.set_polarization_normal((1, 0, 0))
 
         return self._beam_cache
 


### PR DESCRIPTION
Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>