### PR TITLE
Move Image viewer 2d projection edge cases to format classes

### DIFF
--- a/src/dxtbx/format/FormatCBFMiniPilatusDLS12M.py
+++ b/src/dxtbx/format/FormatCBFMiniPilatusDLS12M.py
@@ -130,6 +130,7 @@ class FormatCBFMiniPilatusDLS12M(FormatCBFMiniPilatus):
                 p.set_mu(mu)
                 p.set_px_mm_strategy(px_mm)
                 p.set_raw_image_offset((xmin, ymin))
+                p.set_projection_2d((1, 0, 0, 1), (-j * (195 + 17), 0))
                 self.coords[p.get_name()] = (xmin, ymin, xmax, ymax)
 
             else:
@@ -153,6 +154,7 @@ class FormatCBFMiniPilatusDLS12M(FormatCBFMiniPilatus):
                     p.set_mu(mu)
                     p.set_px_mm_strategy(px_mm)
                     p.set_raw_image_offset((xmin, ymin))
+                    p.set_projection_2d((1, 0, 0, 1), (-j * (195 + 17), -i * (487 + 7)))
                     self.coords[p.get_name()] = (xmin, ymin, xmax, ymax)
 
         detector = self._mask_bad_modules(detector)

--- a/src/dxtbx/model/boost_python/detector.cc
+++ b/src/dxtbx/model/boost_python/detector.cc
@@ -366,6 +366,7 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("rotate_around_origin",
            &rotate_around_origin,
            (arg("axis"), arg("angle"), arg("deg") = true))
+      .def("has_projection_2d", &Detector::has_projection_2d)
       .def("__str__", &detector_to_string)
       .def("__deepcopy__", &detector_deepcopy)
       .def("__copy__", &detector_deepcopy)

--- a/src/dxtbx/model/boost_python/panel.cc
+++ b/src/dxtbx/model/boost_python/panel.cc
@@ -129,6 +129,11 @@ namespace dxtbx { namespace model { namespace boost_python {
     return result;
   }
 
+  boost::python::tuple projection_2d_to_tuple(const Panel &obj){
+    Projection2D projection = obj.get_projection_2d();
+    return boost::python::make_tuple(projection.rotation, projection.translation);
+  }
+
   template <>
   boost::python::dict to_dict<Panel>(const Panel &obj) {
     boost::python::dict result;
@@ -149,6 +154,7 @@ namespace dxtbx { namespace model { namespace boost_python {
     result["gain"] = obj.get_gain();
     result["pedestal"] = obj.get_pedestal();
     result["px_mm_strategy"] = to_dict(obj.get_px_mm_strategy());
+    result["projection_2d"] = projection_2d_to_tuple(obj);
     return result;
   }
 
@@ -203,6 +209,11 @@ namespace dxtbx { namespace model { namespace boost_python {
     if (obj.has_key("trusted_range")) {
       result->set_trusted_range(
         boost::python::extract<tiny<double, 2> >(obj["trusted_range"]));
+    }
+    if (obj.has_key("projection_2d")) {
+      int4 rotation = boost::python::extract<int4>(obj["projection_2d"][0]);
+      int2 translation = boost::python::extract<int2>(obj["projection_2d"][1]);
+      result->set_projection_2d(rotation, translation);
     }
     return result;
   }
@@ -527,6 +538,9 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("get_trusted_range_mask", &Panel::get_trusted_range_mask<int>)
       .def("get_trusted_range_mask", &Panel::get_trusted_range_mask<double>)
       .def("get_untrusted_rectangle_mask", &Panel::get_untrusted_rectangle_mask)
+      .def("get_projection_2d", projection_2d_to_tuple)
+      .def("set_projection_2d", &Panel::set_projection_2d)
+      .def("has_projection_2d", &Panel::has_projection_2d)
       .def("to_dict", &to_dict<Panel>)
       .def("from_dict", &from_dict<Panel>, return_value_policy<manage_new_object>())
       .def("from_dict",

--- a/src/dxtbx/model/boost_python/panel.cc
+++ b/src/dxtbx/model/boost_python/panel.cc
@@ -154,7 +154,9 @@ namespace dxtbx { namespace model { namespace boost_python {
     result["gain"] = obj.get_gain();
     result["pedestal"] = obj.get_pedestal();
     result["px_mm_strategy"] = to_dict(obj.get_px_mm_strategy());
-    result["projection_2d"] = projection_2d_to_tuple(obj);
+    if (obj.has_projection_2d()){
+      result["projection_2d"] = projection_2d_to_tuple(obj);
+    }
     return result;
   }
 

--- a/src/dxtbx/model/detector.h
+++ b/src/dxtbx/model/detector.h
@@ -763,6 +763,15 @@ namespace dxtbx { namespace model {
         (*this)[i].rotate_around_origin(axis, angle);
       }
     }
+  
+    bool has_projection_2d(){
+      for (std::size_t i = 0; i < size(); ++i){
+        if (!(*this)[i].has_projection_2d()){
+          return false;
+        }
+      }
+      return true;
+    }
 
   protected:
     friend std::ostream &operator<<(std::ostream &os, const Detector &d);

--- a/src/dxtbx/model/panel.h
+++ b/src/dxtbx/model/panel.h
@@ -34,6 +34,9 @@ namespace dxtbx { namespace model {
   using scitbx::af::int4;
   using scitbx::af::int2;
 
+ /**
+   * Struct to hold information to project a given panel onto a 2D image 
+   */
   struct Projection2D{
     int4 rotation;
     int2 translation;

--- a/src/dxtbx/model/panel.h
+++ b/src/dxtbx/model/panel.h
@@ -49,7 +49,8 @@ namespace dxtbx { namespace model {
   class Panel : public PanelData {
   public:
     /** Construct the panel with the simple px->mm strategy */
-    Panel() : gain_(1.0), pedestal_(0.0), convert_coord_(new SimplePxMmStrategy()) {}
+    Panel() : gain_(1.0), pedestal_(0.0), convert_coord_(new SimplePxMmStrategy()), 
+    projection_2d(Projection2D{int4(0, 0, 0, 0), int2(0, 0)}) {}
 
     /** Construct with data but no px/mm strategy */
     Panel(std::string type,
@@ -430,7 +431,7 @@ namespace dxtbx { namespace model {
       return projection_2d;
     }
 
-    bool has_projection_2d(){
+    bool has_projection_2d() const{
       int4 default_rotation = int4(0, 0, 0, 0);
       int2 default_translation = int2(0, 0);
 

--- a/src/dxtbx/model/panel.h
+++ b/src/dxtbx/model/panel.h
@@ -31,6 +31,14 @@ namespace dxtbx { namespace model {
   using boost::shared_ptr;
   using scitbx::af::double4;
   using scitbx::af::tiny;
+  using scitbx::af::int4;
+  using scitbx::af::int2;
+
+  struct Projection2D{
+    int4 rotation;
+    int2 translation;
+  };
+
 
   /**
    * A panel class.
@@ -67,7 +75,8 @@ namespace dxtbx { namespace model {
           gain_(1.0),
           pedestal_(0.0),
           convert_coord_(new SimplePxMmStrategy()),
-          identifier_(identifier) {}
+          identifier_(identifier),
+          projection_2d(Projection2D{int4(0, 0, 0, 0), int2(0, 0)}) {}
 
     /** Construct with data with px/mm strategy */
     Panel(std::string type,
@@ -97,7 +106,8 @@ namespace dxtbx { namespace model {
           gain_(1.0),
           pedestal_(0.0),
           convert_coord_(convert_coord),
-          identifier_(identifier) {}
+          identifier_(identifier),
+          projection_2d(Projection2D{int4(0, 0, 0, 0), int2(0, 0)}) {}
 
     virtual ~Panel() {}
 
@@ -408,11 +418,39 @@ namespace dxtbx { namespace model {
       return !(*this == other);
     }
 
+    void set_projection_2d(int4 rotation, int2 translation){
+      projection_2d.rotation = rotation;
+      projection_2d.translation = translation;
+    }
+
+    Projection2D get_projection_2d() const{
+      return projection_2d;
+    }
+
+    bool has_projection_2d(){
+      int4 default_rotation = int4(0, 0, 0, 0);
+      int2 default_translation = int2(0, 0);
+
+      for (std::size_t i = 0; i < 4; ++i){
+        if (projection_2d.rotation[i] != default_rotation[i]){
+          return true;
+        }
+      }
+
+      for (std::size_t i = 0; i < 2; ++i){
+        if (projection_2d.translation[i] != default_translation[i]){
+          return true;
+        }
+      }
+      return false;
+    }
+
   protected:
     double gain_;
     double pedestal_;
     shared_ptr<PxMmStrategy> convert_coord_;
     std::string identifier_;
+    Projection2D projection_2d;
   };
 
   /** Print panel information */

--- a/tests/model/test_detector.py
+++ b/tests/model/test_detector.py
@@ -313,3 +313,54 @@ def test_project_2d():
         assert f1 == pytest.approx(f2)
     for s1, s2 in zip(s, new_s):
         assert s1 == pytest.approx(s2)
+
+
+def test_has_projection_2d():
+
+    # Default values given to a panel when a projection_2d is not set
+    empty_rotation = (0, 0, 0, 0)
+    empty_translation = (0, 0)
+
+    # Valid rotation value
+    rotation = (1, 0, 0, 1)
+
+    ## Test single panel detector
+    detector = create_detector(offset=0)
+
+    # Test detector with no projections set explicity has no 2d projection
+    assert detector.has_projection_2d() is False
+
+    # Test detector with all panels set to empty values has no 2d projection
+    for i in detector:
+        i.set_projection_2d(empty_rotation, empty_translation)
+    assert detector.has_projection_2d() is False
+
+    # Test detector with all panels having 2d projections gives a detector
+    # with a 2d projection
+    image_size = detector[0].get_image_size()
+    for i in detector:
+        i.set_projection_2d(rotation, (image_size[0], 0))
+
+    assert detector.has_projection_2d() is True
+
+    ## Test multipanel detector
+    detector = create_multipanel_detector(offset=0)
+
+    # Test detector with no projections set explicity has no 2d projection
+    assert detector.has_projection_2d() is False
+
+    # Test detector with all panels set to empty values has no 2d projection
+    for i in detector:
+        i.set_projection_2d(empty_rotation, empty_translation)
+    assert detector.has_projection_2d() is False
+
+    image_size = detector[0].get_image_size()
+    for i in detector:
+        # Test detector with only some panels with 2d projections gives a
+        # detector without a 2d projection
+        assert detector.has_projection_2d() is False
+        i.set_projection_2d(rotation, (image_size[0], 0))
+
+    # Test detector with all panels having 2d projections gives a detector
+    # with a 2d projection
+    assert detector.has_projection_2d() is True

--- a/tests/model/test_detector.py
+++ b/tests/model/test_detector.py
@@ -315,6 +315,32 @@ def test_project_2d():
         assert s1 == pytest.approx(s2)
 
 
+def test_panel_has_projection_2d():
+
+    # Default values given to a panel in panel.h
+    # when a projection_2d is not set
+    empty_rotation = (0, 0, 0, 0)
+    empty_translation = (0, 0)
+
+    detector = create_detector(offset=0)
+    panel = detector[0]
+
+    # Valid projection values
+    valid_rotation = (1, 0, 0, 1)
+    valid_translation = detector[0].get_image_size()
+
+    # Test panel with no projections set explicitly has no 2d projection
+    assert panel.has_projection_2d() is False
+
+    # Test panel with empty 2d projection has no 2d projection
+    panel.set_projection_2d(empty_rotation, empty_translation)
+    assert panel.has_projection_2d() is False
+
+    # Test panel with non-empty 2d projection has 2d projection
+    panel.set_projection_2d(valid_rotation, valid_translation)
+    assert panel.has_projection_2d() is True
+
+
 def test_has_projection_2d():
 
     # Default values given to a panel when a projection_2d is not set


### PR DESCRIPTION
This allows 2d projections to be added to a Detector at the creation stage. The purpose of this is to avoid special case checks buried in image_viewer scripts for detectors that do not work with project_2d (i.e FormatCBFMiniPilatusDLS12M). Unique projection behaviour is now defined only in a format class. image_viewer scripts then just use explicit projections over project_2d if they are present on the Detector. projection_2d keys are only added to .expt files if they have been manually set, to avoid noise in normal detectors.