### PR TITLE
Py abs

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Disable reading non-image pickle files

--- a/src/dxtbx/format/FormatPY.py
+++ b/src/dxtbx/format/FormatPY.py
@@ -5,9 +5,10 @@ import pickle
 import sys
 
 from dxtbx import IncorrectFormatError
-from dxtbx.format.Format import Format
+from dxtbx.format.Format import Format, abstract
 
 
+@abstract
 class FormatPY(Format):
     """Let's take an educated guess as to how to recognize a Python
     pickle file containing a dictionary.  Not easy because there are


### PR DESCRIPTION
This enables `dials.show` and `dials.image_viewer` on reflection tables created by cctbx.xfel.merge, which at present is [still making pickle files](https://github.com/cctbx/cctbx_project/blob/master/xfel/merging/command_line/merge.py#L201).  Otherwise, the reflection table files are caught by FormatPY and read as an image with no data.