### PR TITLE
For dials/dials#1998 bring in UUID4

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Add method ersatz_uuid4 which gives an implementation of a random 128 bit UUID4

--- a/src/dxtbx/format/FormatHDF5EigerNearlyNexus.py
+++ b/src/dxtbx/format/FormatHDF5EigerNearlyNexus.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-import uuid
 
 import h5py
 import numpy as np
@@ -23,6 +22,7 @@ from dxtbx.format.nexus import (
     NXmxReader,
     generate_scan_model,
 )
+from dxtbx.util import ersatz_uuid4
 
 
 def find_entries(nx_file):
@@ -319,7 +319,7 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
 
     def _start(self):
         # Read the file structure
-        temp_file = "tmp_master_%s.nxs" % uuid.uuid1().hex
+        temp_file = "tmp_master_%s.nxs" % ersatz_uuid4()
         fixer = EigerNXmxFixer(self._image_file, temp_file)
         reader = NXmxReader(handle=fixer.handle)
 

--- a/src/dxtbx/util/__init__.py
+++ b/src/dxtbx/util/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import os
 import sys
 from urllib.parse import urlparse
 
@@ -80,3 +81,10 @@ def get_url_scheme(url) -> str:
     """Extract the URL scheme from the string url, respecting Windows file paths"""
 
     return urlparse(str(url)).scheme if "://" in str(url) else ""
+
+
+def ersatz_uuid4() -> str:
+    """Generate an ersatz UUID4 i.e. random 128 bit UUID."""
+
+    h = "%032x" % int.from_bytes(os.urandom(16), byteorder="little")
+    return "%s-%s-%s-%s-%s" % (h[:8], h[8:12], h[12:16], h[16:20], h[20:])


### PR DESCRIPTION
UUID generation involves spawning a subprocess on import which appears to
cause problems in large-rank MPI jobs - however we only really need random
128 bit UUID4's which can be generated easily.