### PR TITLE
Represent more NXmx quantities with Pint

### DIFF
--- a/src/dxtbx/nexus/nxmx.py
+++ b/src/dxtbx/nexus/nxmx.py
@@ -49,9 +49,9 @@ logger = logging.getLogger(__name__)
 NXNode = Union[h5py.File, h5py.Group]
 
 
-def h5str(h5_value: str | np.bytes_ | bytes) -> str:
+def h5str(h5_value: str | np.bytes_ | bytes | None) -> str | None:
     """
-    Convert a value returned an h5py attribute to str.
+    Convert a value returned from an h5py attribute to str.
 
     h5py can return either a bytes-like (numpy.string_) or str object
     for attribute values depending on whether the value was written as

--- a/tests/nexus/test_nxmx.py
+++ b/tests/nexus/test_nxmx.py
@@ -105,6 +105,24 @@ def test_nxmx(nxmx_example):
     assert nxentry.source.short_name == "DLS"
 
 
+def test_nxmx_single_value_properties(dials_data):
+    """
+    Check we correctly interpret scalar data stored as single-valued arrays.
+
+    Some data sources, notably Dectris Eiger detectors at Diamond Light Source,
+    record some scalar data as length-1 arrays.  Check here that we correctly
+    interpret such data as scalars.  The dials_data four_circle_eiger data set is an
+    example of one such data set.
+    """
+    data = dials_data("four_circle_eiger", pathlib=True)
+    with h5py.File(data / "03_CuHF2pyz2PF6b_P_O" / "CuHF2pyz2PF6b_P_O_02.nxs") as f:
+        nx_detector = nxmx.NXmx(f).entries[0].instruments[0].detectors[0]
+        # These scalar parameters are populated with data from single-valued arrays.
+        assert nx_detector.pixel_mask_applied is True
+        assert nx_detector.saturation_value == 1382150
+        assert nx_detector.serial_number == "E-08-0148"
+
+
 def test_get_rotation_axes(nxmx_example):
     sample = nxmx.NXmx(nxmx_example).entries[0].samples[0]
     dependency_chain = nxmx.get_dependency_chain(sample.depends_on)

--- a/tests/nexus/test_nxmx.py
+++ b/tests/nexus/test_nxmx.py
@@ -5,6 +5,7 @@ import datetime
 import dateutil
 import h5py
 import numpy as np
+import pint
 import pytest
 
 from dxtbx.nexus import nxmx
@@ -118,6 +119,7 @@ def test_nxmx_single_value_properties(dials_data):
     with h5py.File(data / "03_CuHF2pyz2PF6b_P_O" / "CuHF2pyz2PF6b_P_O_02.nxs") as f:
         nx_detector = nxmx.NXmx(f).entries[0].instruments[0].detectors[0]
         # These scalar parameters are populated with data from single-valued arrays.
+        assert nx_detector.distance == pint.Quantity(85, "mm")
         assert nx_detector.pixel_mask_applied is True
         assert nx_detector.saturation_value == 1382150
         assert nx_detector.serial_number == "E-08-0148"


### PR DESCRIPTION
According to the NeXus specification, we currently represent as `int`s or `float`s some quantities that have, or can have, measurement units.  Ensure that these data are represented as `pint.Quantity` instances instead, so that we can retain any units defined in the corresponding HDF5 data set attributes.

As a side-effect, this introduces a test for the changes in #460.