### PR TITLE
Use pytest<=7.0.1 for CI

### DIFF
--- a/.azure-pipelines/ci-conda-env.txt
+++ b/.azure-pipelines/ci-conda-env.txt
@@ -30,7 +30,7 @@ conda-forge::pytest-forked
 conda-forge::pytest-mock
 conda-forge::pytest-timeout
 conda-forge::pytest-xdist
-conda-forge::pytest
+conda-forge::pytest<=7.0.1
 conda-forge::requests
 conda-forge::scipy
 conda-forge::scons

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Pin pytest<=7.0.1 for ci to workaround pytest-azurepipelines incompatibility with pytest 7.1.0


### PR DESCRIPTION
Workaround pytest-azurepipelines issue with pytest 7.1.0
See tonybaloney/pytest-azurepipelines#57

pytest_warning_captured removed in 7.1.0:
https://docs.pytest.org/en/7.1.x/changelog.html#pytest-7-1-0-2022-03-13