### PR TITLE
Stage 1 remove datablock

### DIFF
--- a/src/dxtbx/datablock.py
+++ b/src/dxtbx/datablock.py
@@ -30,6 +30,8 @@ class DataBlock:
     def __init__(self, imagesets=None):
         """Instantiate from a list of imagesets."""
 
+        raise RuntimeError("DataBlock class now removed")
+
         warnings.warn(
             "Datablocks are deprecated; please use ExperimentLists instead",
             UserWarning,


### PR DESCRIPTION
Obviously results in some DIALS test failures, but very few:

```
Results (1352.51s):
    1517 passed
       3 failed
         - tests/model/test_experiment_list.py:534 test_experimentlist_factory_from_datablock
         - tests/model/test_experiment_list.py:562 test_experimentlist_to_datablock_imageset
         - tests/model/test_experiment_list.py:577 test_experimentlist_to_datablock_centroid_test_data
```

As promised, 18th March starting this work