### PR TITLE
Retire py.path in favour of pathlib

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,8 @@ import socket
 
 import pytest
 
+from dials.conftest import run_in_tmp_path  # noqa; lgtm; exported symbol
+
 collect_ignore = []
 
 
@@ -70,13 +72,3 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "regression" in item.keywords:
                 item.add_marker(skip_regression)
-
-
-@pytest.fixture
-def run_in_tmpdir(tmpdir):
-    """Shortcut to create a temporary directory and then run the test inside
-    this directory."""
-    cwd = os.getcwd()
-    tmpdir.chdir()
-    yield tmpdir
-    os.chdir(cwd)

--- a/tests/format/test_cbf_mini_as_file.py
+++ b/tests/format/test_cbf_mini_as_file.py
@@ -21,7 +21,7 @@ from dxtbx.model.experiment_list import (
         "image_examples/DLS_I02/X4_wide_M1S4_1_0001.cbf",
     ],
 )
-def test_cbf_writer(image_file, dials_regression, run_in_tmpdir):
+def test_cbf_writer(image_file, dials_regression, run_in_tmp_path):
     filename = os.path.join(dials_regression, image_file)
     imageset = ExperimentListFactory.from_filenames([filename])[0].imageset
 


### PR DESCRIPTION
Depends on dials/dials#2038 for `run_in_tmp_path` fixture to replace `run_in_tmpdir`.