### PR TITLE
Remove unnecessary dials import

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+``FormatNexusJungfrauExt``: Remove unnecessary dials import dependency

--- a/src/dxtbx/format/FormatNexusJungfrauExt.py
+++ b/src/dxtbx/format/FormatNexusJungfrauExt.py
@@ -5,12 +5,13 @@ import sys
 import h5py
 import numpy as np
 
+from scitbx.array_family import flex
+
 try:
     from xfel.util.jungfrau import pad_stacked_format
 except ImportError:
     pass
 
-from dials.array_family import flex
 
 from dxtbx.format.FormatNexus import FormatNexus
 from dxtbx.format.nexus import h5str


### PR DESCRIPTION
We only use flex.double, so use scitbx.array_family.flex instead