### PR TITLE
Update FormatBrukerFixedChi.py

### DIFF
--- a/src/dxtbx/format/FormatBrukerFixedChi.py
+++ b/src/dxtbx/format/FormatBrukerFixedChi.py
@@ -25,7 +25,8 @@ class FormatBrukerFixedChi(FormatBruker):
     def _start(self):
         self.header_dict = {}
         image_blob = open(self._image_file, 'rb').read()
-        header_text = image_blob.decode(errors='ignore').split("......")[0]
+        header_text = image_blob.split(b"......")[0].decode()
+        # header_text = image_blob.decode(errors='ignore').split("......")[0]
         for j in range(0, len(header_text), 80):
             record = header_text[j : j + 80]
             if record.startswith("CFR:"):

--- a/src/dxtbx/format/FormatBrukerFixedChi.py
+++ b/src/dxtbx/format/FormatBrukerFixedChi.py
@@ -24,7 +24,8 @@ class FormatBrukerFixedChi(FormatBruker):
 
     def _start(self):
         self.header_dict = {}
-        header_text = open(self._image_file).read().split("......")[0]
+        image_blob = open(self._image_file, 'rb').read()
+        header_text = image_blob.decode(errors='ignore').split("......")[0]
         for j in range(0, len(header_text), 80):
             record = header_text[j : j + 80]
             if record.startswith("CFR:"):


### PR DESCRIPTION
#### Note
I initially raised this in `dials`: 
https://github.com/dials/dials/issues/2097 
but I have since realized that under the new package architecture, the issue lies in `dxtbx`.

This change should eliminate a 
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x85 in position 20218: invalid start byte`
error caused when importing `.sfrm` diffraction images collected on an outdated Bruker diffractometer.

More details in the linked issue above, and also in the issue in this repo that I will create shortly