### PR TITLE
DIALS 3.9.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Billy K. Poon
 Clemens Weninger
 Daniel Paley
 David Waterman
+Dennis Brookner
 Derek Mendez
 Dorothee Liebschner
 Graeme Winter

--- a/newsfragments/518.bugfix
+++ b/newsfragments/518.bugfix
@@ -1,0 +1,1 @@
+Correct a unicode error reading Bruker ``.sfrm`` files. With thanks to `Dennis Brookner <https://github.com/dennisbrookner>`_ for this change.

--- a/src/dxtbx/format/FormatBrukerFixedChi.py
+++ b/src/dxtbx/format/FormatBrukerFixedChi.py
@@ -24,7 +24,8 @@ class FormatBrukerFixedChi(FormatBruker):
 
     def _start(self):
         self.header_dict = {}
-        header_text = open(self._image_file).read().split("......")[0]
+        image_blob = open(self._image_file, 'rb').read()
+        header_text = image_blob.split(b"......")[0].decode()
         for j in range(0, len(header_text), 80):
             record = header_text[j : j + 80]
             if record.startswith("CFR:"):


### PR DESCRIPTION
Bugfixes
--------

- Correct a unicode error reading Bruker ``.sfrm`` files. With thanks to `Dennis Brookner <https://github.com/dennisbrookner>`_ for this change. (cctbx/dxtbx#518)