### PR TITLE
Fix dxtbx.image_average for raster scans

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Fix dxtbx.image_average for raster scans

--- a/src/dxtbx/command_line/image_average.py
+++ b/src/dxtbx/command_line/image_average.py
@@ -256,6 +256,10 @@ def run(argv=None):
 
     experiments = ExperimentListFactory.from_filenames([paths[0]], load_models=False)
     if len(paths) == 1:
+        if len(experiments) == 1 and len(experiments[0].imageset) > 1:
+            experiments = ExperimentListFactory.from_stills_and_crystal(
+                experiments[0].imageset, None, load_models=False
+            )
         worker = multi_image_worker(command_line, paths[0], experiments)
         iterable = list(range(len(experiments)))
     else:


### PR DESCRIPTION
image_average expects a list of experiments to iterator over, one image per experiment.  This fix slices up an imageset to fit what image_average expects.  It now works on an ImageSequence, like from a raster scan.