### PR TITLE
DIALS 3.10.1

### DIFF
--- a/newsfragments/524.bugfix
+++ b/newsfragments/524.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.install_format``: Handle case on MacOS ``.pkg`` installations where URL-formats could not be installed.


### PR DESCRIPTION
Bugfixes
--------

- ``dxtbx.install_format``: Handle case on MacOS ``.pkg`` installations where URL-formats could not be installed. (cctbx/dxtbx#524)