### PR TITLE
DIALS 3.8.8

### DIFF
--- a/newsfragments/525.bugfix
+++ b/newsfragments/525.bugfix
@@ -1,0 +1,1 @@
+Fix ``mask_untrusted_circle()`` crash when untrusted circle extends outside detector. This affected ``dials.generate_mask``.

--- a/src/dxtbx/masking/masking.h
+++ b/src/dxtbx/masking/masking.h
@@ -72,7 +72,7 @@ namespace dxtbx { namespace masking {
     x0 = std::max(x0, 0);
     y0 = std::max(y0, 0);
     x1 = std::min(x1, (int)width);
-    y1 = std::max(y1, (int)height);
+    y1 = std::min(y1, (int)height);
     DXTBX_ASSERT(x1 > x0);
     DXTBX_ASSERT(y1 > y0);
     double r2 = radius * radius;


### PR DESCRIPTION
Bugfixes
--------

- Fix ``mask_untrusted_circle()`` crash when untrusted circle extends outside detector. This affected ``dials.generate_mask``. (cctbx/dxtbx#525)