### PR TITLE
Remove printing of error

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+dxtbx: remote error message printing (which is not an error)

--- a/src/dxtbx/model/experiment_list.py
+++ b/src/dxtbx/model/experiment_list.py
@@ -1213,9 +1213,9 @@ def _merge_scans(
                 else:
                     prev.scan.append(record.scan, scan_tolerance=scan_tolerance)
             except RuntimeError as e:
-                print(e)
                 logger.debug(
-                    "  Failed to merge record %s with previous - writing new scan"
+                    "  Failed to merge record %s with previous - writing new scan",
+                    str(e),
                 )
             else:
                 # If we appended, then we don't need to keep this record's scan


### PR DESCRIPTION
This is not an error, it is by design. We could do this better but for now just removing the print is an improvement. Fixes dials/dials#2253.

Removes printing of

```
dxtbx Internal Error: /Users/graeme/git/dials/modules/dxtbx/src/dxtbx/model/scan.h(314): DXTBX_ASSERT(image_range_[1] + 1 == rhs.image_range_[0]) failure.
```

etc. 