### PR TITLE
Mpi image average2

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Bugfixes for MPI run. Updated help message to identify the mpi option as a bool. Updated image_worker.__call__ to correctly count images. Changed how the iterable is split into smaller iterables for each rank. This allows the function to work when there are more ranks than iterables and to include the last n_ranks - 1 iterables.

--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,1 +1,1 @@
-Bugfixes for MPI run. Updated help message to identify the mpi option as a bool. Updated image_worker.__call__ to correctly count images. Changed how the iterable is split into smaller iterables for each rank. This allows the function to work when there are more ranks than iterables and to include the last n_ranks - 1 iterables.
+dxtbx.image_average: fix a crash from using more processors than images when using MPI.


### PR DESCRIPTION
Bug fixes that enable dxtbx.image_average to be used with mpi when there are more ranks than images.