### PR TITLE
Ensure conversion to flex.int via conversion to np.intc

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``NXmx``: Ensure integer data types get converted to ``flex.int``, i.e. ``int`` C-type, on all platforms

--- a/src/dxtbx/nexus/__init__.py
+++ b/src/dxtbx/nexus/__init__.py
@@ -498,7 +498,7 @@ def _dataset_as_flex(
         np.float32,
     )
     if np.issubdtype(data_np.dtype, np.integer):
-        data_np = data_np.astype(np.int32, copy=False)
+        data_np = data_np.astype(np.intc, copy=False)
     elif data_np.dtype in np_float_types:
         data_np = data_np.astype(np.float32, copy=False)
     else:


### PR DESCRIPTION
On Linux `np.int32` is equivalent to `np.intc` and hence an `int` C-type. On Windows `np.int32` is equivalent to `np.int_` and hence a `long` C-type.

Explicitly converting to `np.intc` ensures it is represented by an `int` C-type on all platforms.