### PR TITLE
cbf_writer: cctbx function expects `trusted_range`

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``FullCBFWriter``: bug fix for setting underload/undefined values

--- a/src/dxtbx/format/cbf_writer.py
+++ b/src/dxtbx/format/cbf_writer.py
@@ -207,13 +207,12 @@ class FullCBFWriter:
             # of 'overload' is in fact saturation - i.e. the max-trusted-value, while
             # the undefined_value is below the min-trusted-value.
             trusted_ranges = [panel.get_trusted_range() for panel in detector]
-            undef_overl = [(e[0] - 1, e[1]) for e in trusted_ranges]
             try:
                 add_frame_specific_cbf_tables(
                     cbf,
                     beam.get_wavelength(),
                     "unknown",
-                    undef_overl,
+                    trusted_ranges,
                     diffrn_id,
                     False,
                     gain=[panel.get_gain() for panel in detector],
@@ -225,7 +224,7 @@ class FullCBFWriter:
                     cbf,
                     beam.get_wavelength(),
                     "unknown",
-                    undef_overl,
+                    trusted_ranges,
                     diffrn_id,
                     False,
                     gain=[panel.get_gain() for panel in detector],


### PR DESCRIPTION
Otherwise underload and undefined are set to 1 lower than their intended values.

The function [`add_frame_specific_cbf_tables`](https://github.com/cctbx/cctbx_project/blob/b64fa3e1ffa81e8c2de3f2f4c3abc83755676cef/xfel/cftbx/detector/cspad_cbf_tbx.py#L732) in cctbx expects `trusted_range` but we were subtracting `-1` from the minimum trusted value before passing to the function.

This caused the test `tests/command_line/test_average.py` to fail - I'm not sure why this wasn't noticed before.