### PR TITLE
Fixes for EMBL beamlines at PETRA

### DIFF
--- a/src/dxtbx/format/FormatCBFMiniEigerPetraP13.py
+++ b/src/dxtbx/format/FormatCBFMiniEigerPetraP13.py
@@ -1,0 +1,38 @@
+"""An implementation of the CBF image reader for Eiger images"""
+
+
+from __future__ import annotations
+
+import sys
+
+from dxtbx.format.FormatCBFMiniEiger import FormatCBFMiniEiger
+
+
+class FormatCBFMiniEigerPetraP13(FormatCBFMiniEiger):
+    """A class for reading mini CBF format Eiger images, and correctly
+    constructing a model for the experiment from this. This tuned for Petra P13"""
+
+    @staticmethod
+    def understand(image_file):
+        """Check to see if this looks like an Eiger mini CBF format image,
+        i.e. we can make sense of it."""
+
+        header = FormatCBFMiniEiger.get_cbf_header(image_file)
+
+        for record in header.split("\n"):
+            if (
+                "# detector" in record.lower()
+                and "eiger" in record.lower()
+                and "E-32-0107" in record
+            ):
+                return True
+
+        return False
+
+    def _goniometer(self):
+        return self._goniometer_factory.known_axis((1, 0, 0))
+
+
+if __name__ == "__main__":
+    for arg in sys.argv[1:]:
+        print(FormatCBFMiniEigerPetraP13.understand(arg))

--- a/src/dxtbx/format/FormatCBFMiniEigerPetraP14.py
+++ b/src/dxtbx/format/FormatCBFMiniEigerPetraP14.py
@@ -23,7 +23,7 @@ class FormatCBFMiniEigerPetraP14(FormatCBFMiniEiger):
             if (
                 "# detector" in record.lower()
                 and "eiger" in record.lower()
-                and "E-32-0107" in record
+                and "E-32-0129" in record
             ):
                 return True
 


### PR DESCRIPTION
Processing data recently collected at PETRA P13 using DIALS/XDS failed because the rotation axis was defined incorrectly. There is a new Eiger CdTe detector installed at P14 with serial number E-32-0129 and the Eiger with serial number E-32-0107 was moved to P13. This lead to the P14 rotation axis settings being applied to the P13 data, which resulted in indexing failures.