### PR TITLE
Handle no conda for system_includes

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -119,7 +119,7 @@ if not env_etc.no_boost_python and hasattr(env_etc, "boost_adaptbx_include"):
     env = env_no_includes_boost_python_ext.Clone()
 
     # Don't surface warnings from system or cctbx_project headers
-    system_includes = [x for x in env_etc.conda_cpppath if x]
+    system_includes = [x for x in env_etc.conda_cpppath if x] if libtbx.env.build_options.use_conda else []
     system_includes.append(str(Path(env_etc.scitbx_dist).parent))
     env.Append(CXXFLAGS=[f"-isystem{x}" for x in system_includes])
     env.Append(SHCXXFLAGS=[f"-isystem{x}" for x in system_includes])

--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Bugfix for environments without conda


### PR DESCRIPTION
Relevant e.g. for virtualenv builds, using a facility provided python