### PR TITLE
Workaround change to DECTRIS file writer

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+bugfix: read bit_depth_image from DECTRIS NXmx files rather than readout, since the on-disk format is most useful

--- a/src/dxtbx/format/FormatNXmxEigerFilewriter.py
+++ b/src/dxtbx/format/FormatNXmxEigerFilewriter.py
@@ -32,6 +32,12 @@ class FormatNXmxEigerFilewriter(FormatNXmx):
         nxmx_obj = nxmx.NXmx(fh)
         nxentry = nxmx_obj.entries[0]
 
+        # possibly useful datum for later
+        try:
+            self._bit_depth_image = fh["entry/instrument/detector/bit_depth_image"][()]
+        except KeyError:
+            self._bit_depth_image = None
+
         nxdetector = nxentry.instruments[0].detectors[0]
         if nxdetector.underload_value is None:
             nxdetector.underload_value = 0
@@ -47,7 +53,11 @@ class FormatNXmxEigerFilewriter(FormatNXmx):
         nxmx_obj = self._get_nxmx(self._cached_file_handle)
         nxdata = nxmx_obj.entries[0].data[0]
         nxdetector = nxmx_obj.entries[0].instruments[0].detectors[0]
-        raw_data = get_raw_data(nxdata, nxdetector, index)
+
+        bit_depth = self._bit_depth_image
+
+        raw_data = get_raw_data(nxdata, nxdetector, index, bit_depth)
+
         if self._bit_depth_readout:
             # if 32 bit then it is a signed int, I think if 8, 16 then it is
             # unsigned with the highest two values assigned as masking values
@@ -63,7 +73,7 @@ class FormatNXmxEigerFilewriter(FormatNXmx):
 
 
 def get_raw_data(
-    nxdata: nxmx.NXdata, nxdetector: nxmx.NXdetector, index: int
+    nxdata: nxmx.NXdata, nxdetector: nxmx.NXdetector, index: int, bit_depth: int
 ) -> tuple[flex.float | flex.double | flex.int, ...]:
     """Return the raw data for an NXdetector.
 
@@ -85,6 +95,6 @@ def get_raw_data(
     all_data = []
     sliced_outer = data[index]
     for module_slices in get_detector_module_slices(nxdetector):
-        data_as_flex = _dataset_as_flex(sliced_outer, tuple(module_slices))
+        data_as_flex = _dataset_as_flex(sliced_outer, tuple(module_slices), bit_depth)
         all_data.append(data_as_flex)
     return tuple(all_data)


### PR DESCRIPTION
Now look for bit_depth_image which appears to be documented in their standard file description, despite not being NXmx compliant. This is a local fix to the file.

Fixes dials/dials/#2401