### PR TITLE
DIALS 3.14.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.14.0
+current_version = 3.14.2
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<release>[a-z]+)?(?P<patch>\d+)?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.14.2 (2023-05-16)
+=========================
+
+Bugfixes
+--------
+
+- Compatibility fix for the DECTRIS Eiger FileWriter. Recent FileWriter versions split bit depth metadata into two separate items, ``bit_depth_readout`` from the NXmx standard, and the new ``bit_depth_image`` field. This adds support for the latter, and now passes the metadata through into image conversion. (`#632 <https://github.com/cctbx/dxtbx/issues/632>`_)
+
+
 dxtbx 3.14.0 (2023-04-12)
 =========================
 

--- a/newsfragments/632.bugfix
+++ b/newsfragments/632.bugfix
@@ -1,0 +1,1 @@
+Compatibility fix for the DECTRIS Eiger FileWriter. Recent FileWriter versions split bit depth metadata into two separate items, ``bit_depth_readout`` from the NXmx standard, and the new ``bit_depth_image`` field. This adds support for the latter, and now passes the metadata through into image conversion.

--- a/newsfragments/632.bugfix
+++ b/newsfragments/632.bugfix
@@ -1,1 +1,0 @@
-Compatibility fix for the DECTRIS Eiger FileWriter. Recent FileWriter versions split bit depth metadata into two separate items, ``bit_depth_readout`` from the NXmx standard, and the new ``bit_depth_image`` field. This adds support for the latter, and now passes the metadata through into image conversion.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from build import build
 
 # Static version number which is updated by bump2version
 # Do not change this manually - use 'bump2version <major/minor/patch/release>'
-__version_tag__ = "3.14.0"
+__version_tag__ = "3.14.2"
 
 setup_kwargs = {
     "name": "dxtbx",

--- a/src/dxtbx/format/FormatNXmxEigerFilewriter.py
+++ b/src/dxtbx/format/FormatNXmxEigerFilewriter.py
@@ -28,6 +28,19 @@ class FormatNXmxEigerFilewriter(FormatNXmx):
         """Initialise the image structure from the given file."""
         super().__init__(image_file, **kwargs)
 
+    def _start(self):
+        super()._start()
+        try:
+            # This is (currently) a DECTRIS-specific non-standard item that
+            # we will use in preference to bit_depth_readout (see below)
+            self._bit_depth_image = int(
+                self._cached_file_handle["/entry/instrument/detector/bit_depth_image"][
+                    ()
+                ]
+            )
+        except KeyError:
+            self._bit_depth_image = None
+
     def _get_nxmx(self, fh: h5py.File):
         nxmx_obj = nxmx.NXmx(fh)
         nxentry = nxmx_obj.entries[0]
@@ -47,14 +60,21 @@ class FormatNXmxEigerFilewriter(FormatNXmx):
         nxmx_obj = self._get_nxmx(self._cached_file_handle)
         nxdata = nxmx_obj.entries[0].data[0]
         nxdetector = nxmx_obj.entries[0].instruments[0].detectors[0]
-        raw_data = get_raw_data(nxdata, nxdetector, index)
-        if self._bit_depth_readout:
+
+        # Prefer bit_depth_image over bit_depth_readout since the former
+        # actually corresponds to the bit depth of the images as stored on
+        # disk. See also:
+        #   https://www.dectris.com/support/downloads/header-docs/nexus/
+        bit_depth = self._bit_depth_image or self._bit_depth_readout
+        raw_data = get_raw_data(nxdata, nxdetector, index, bit_depth)
+
+        if bit_depth:
             # if 32 bit then it is a signed int, I think if 8, 16 then it is
             # unsigned with the highest two values assigned as masking values
-            if self._bit_depth_readout == 32:
+            if bit_depth == 32:
                 top = 2**31
             else:
-                top = 2**self._bit_depth_readout
+                top = 2**bit_depth
             for data in raw_data:
                 d1d = data.as_1d()
                 d1d.set_selected(d1d == top - 1, -1)
@@ -63,7 +83,10 @@ class FormatNXmxEigerFilewriter(FormatNXmx):
 
 
 def get_raw_data(
-    nxdata: nxmx.NXdata, nxdetector: nxmx.NXdetector, index: int
+    nxdata: nxmx.NXdata,
+    nxdetector: nxmx.NXdetector,
+    index: int,
+    bit_depth: int | None = None,
 ) -> tuple[flex.float | flex.double | flex.int, ...]:
     """Return the raw data for an NXdetector.
 
@@ -85,6 +108,8 @@ def get_raw_data(
     all_data = []
     sliced_outer = data[index]
     for module_slices in get_detector_module_slices(nxdetector):
-        data_as_flex = _dataset_as_flex(sliced_outer, tuple(module_slices))
+        data_as_flex = _dataset_as_flex(
+            sliced_outer, tuple(module_slices), bit_depth=bit_depth
+        )
         all_data.append(data_as_flex)
     return tuple(all_data)


### PR DESCRIPTION
Bugfixes
--------

- Compatibility fix for the DECTRIS Eiger FileWriter. Recent FileWriter versions split bit depth metadata into two separate items, ``bit_depth_readout`` from the NXmx standard, and the new ``bit_depth_image`` field. This adds support for the latter, and now passes the metadata through into image conversion. (cctbx/dxtbx#632)