### PR TITLE
DIALS 3.15.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.15.0
+current_version = 3.15.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<release>[a-z]+)?(?P<patch>\d+)?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.15.1 (2023-06-29)
+=========================
+
+Bugfixes
+--------
+
+- ``dxtbx.dlsnxs2cbf``: Fix import overwritten by local variable. (`#641 <https://github.com/cctbx/dxtbx/issues/641>`_)
+
+
 dxtbx 3.15.0 (2023-06-13)
 =========================
 

--- a/newsfragments/641.bugfix
+++ b/newsfragments/641.bugfix
@@ -1,1 +1,0 @@
-``dxtbx.dlsnxs2cbf``: Fix import overwritten by local variable.

--- a/newsfragments/641.bugfix
+++ b/newsfragments/641.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.dlsnxs2cbf``: Fix import overwritten by local variable.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from build import build
 
 # Static version number which is updated by bump2version
 # Do not change this manually - use 'bump2version <major/minor/patch/release>'
-__version_tag__ = "3.15.0"
+__version_tag__ = "3.15.1"
 
 setup_kwargs = {
     "name": "dxtbx",

--- a/src/dxtbx/command_line/dlsnxs2cbf.py
+++ b/src/dxtbx/command_line/dlsnxs2cbf.py
@@ -2,7 +2,7 @@
 Convert a NXmx-format NeXus file to a set of CBF-format image files.
 
 Note that this tool does not produce full imgCIF-format files, only
-Dectris-style mini-CBF files consisting of a plain text simplified
+DECTRIS-style mini-CBF files consisting of a plain text simplified
 header and the binary compressed image data.  The simplified header
 does not contain a full description of the experiment geometry and some
 metadata, including the detector orientation, are unspecified.  As
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import dxtbx.util.dlsnxs2cbf
 
-parser = argparse.ArgumentParser(description=__doc__)
+parser = argparse.ArgumentParser(description=__doc__, prog="dxtbx.dlsnxs2cbf")
 parser.add_argument(
     "nexus_file", metavar="nexus-file", help="Input NeXus file.", type=Path
 )

--- a/src/dxtbx/util/dlsnxs2cbf.py
+++ b/src/dxtbx/util/dlsnxs2cbf.py
@@ -12,11 +12,12 @@ import pint
 from tqdm import tqdm
 
 import dxtbx.model
+import dxtbx.nexus
 from dxtbx.ext import compress
 
 
-def compute_cbf_header(nxmx: nxmx.NXmx, nn: int):
-    nxentry = nxmx.entries[0]
+def compute_cbf_header(nxmx_obj: nxmx.NXmx, nn: int):
+    nxentry = nxmx_obj.entries[0]
     nxsample = nxentry.samples[0]
     nxinstrument = nxentry.instruments[0]
     nxdetector = nxinstrument.detectors[0]
@@ -145,11 +146,11 @@ def make_cbf(
     with h5py.File(in_name) as f:
         start_tag = binascii.unhexlify("0c1a04d5")
 
-        nxmx = nxmx.NXmx(f)
-        nxsample = nxmx.entries[0].samples[0]
-        nxinstrument = nxmx.entries[0].instruments[0]
+        nxmx_obj = nxmx.NXmx(f)
+        nxsample = nxmx_obj.entries[0].samples[0]
+        nxinstrument = nxmx_obj.entries[0].instruments[0]
         nxdetector = nxinstrument.detectors[0]
-        nxdata = nxmx.entries[0].data[0]
+        nxdata = nxmx_obj.entries[0].data[0]
 
         dependency_chain = nxmx.get_dependency_chain(nxsample.depends_on)
         scan_axis = None
@@ -183,7 +184,7 @@ def make_cbf(
 
         print(f"Writing images to {template}{'#' * num_digits}.cbf:")
         for j in tqdm(range(num_images), unit=" images"):
-            header = compute_cbf_header(nxmx, j)
+            header = compute_cbf_header(nxmx_obj, j)
             (data,) = dxtbx.nexus.get_raw_data(nxdata, nxdetector, j)
             if bit_depth_readout:
                 # if 32 bit then it is a signed int, I think if 8, 16 then it is

--- a/tests/command_line/test_dlsnxs2cbf.py
+++ b/tests/command_line/test_dlsnxs2cbf.py
@@ -69,10 +69,9 @@ def test_dlsnxs2cbf_deleted_axis(dials_data, tmp_path, remove_axis):
     make_cbf(tmp_path / master, template=str(tmp_path / "image_%04d.cbf"))
 
 
-@pytest.mark.xfail(reason="Broken for old data while collecting new data")
 def test_dlsnxs2cbf_help(capsys):
     with pytest.raises(SystemExit):
         run(["-h"])
     captured = capsys.readouterr()
-    assert parser.description in captured.out
-    assert "Template cbf output name e.g. 'image_%04d.cbf'" in captured.out
+    assert parser.description.splitlines()[0] in captured.out
+    assert "usage: dxtbx.dlsnxs2cbf" in captured.out

--- a/tests/format/test_FormatNXmxDLS16M.py
+++ b/tests/format/test_FormatNXmxDLS16M.py
@@ -98,6 +98,7 @@ def test_rotation_scan_i04_2022_run_5(master_h5):
     assert masker.get_mask(imageset.get_detector(), 100)[0].count(False) == 1110799
 
 
+@pytest.mark.skip(reason="Data erased from CM visit")
 @pytest.mark.parametrize(
     "master_h5",
     [
@@ -116,6 +117,7 @@ def test_masked_i04_32bit(master_h5):
     assert flex.max(imageset[0][0]) != 0x7FFFFFFF
 
 
+@pytest.mark.skip(reason="Data erased from CM visit")
 @pytest.mark.parametrize(
     "master_h5",
     [

--- a/tests/format/test_FormatNXmxDLS16MI03.py
+++ b/tests/format/test_FormatNXmxDLS16MI03.py
@@ -11,6 +11,7 @@ dials = pytest.importorskip("dials")
 pytest.importorskip("h5py")
 
 
+@pytest.mark.skip(reason="Data erased from CM visit")
 @pytest.mark.parametrize(
     "master_h5,masked_count",
     [


### PR DESCRIPTION
Bugfixes
--------

- ``dxtbx.dlsnxs2cbf``: Fix import overwritten by local variable. (cctbx/dxtbx#641)