### PR TITLE
Don't set batch offset when creating image sequences

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Don't set batch offset when creating image sequences.

--- a/src/dxtbx/imageset.py
+++ b/src/dxtbx/imageset.py
@@ -570,9 +570,6 @@ class ImageSetFactory:
 
         # Set the image range
         array_range = (min(indices) - 1, max(indices))
-        if scan is not None:
-            assert array_range == scan.get_array_range()
-            scan.set_batch_offset(array_range[0])
 
         # Get the format object and reader
         if format_class is None:


### PR DESCRIPTION
This should now be unnecessary following https://github.com/cctbx/dxtbx/pull/634 and related changes.

Removes an unintended use of the batch offset property

Fixes https://github.com/dials/dials/issues/1347

Will not be merged without thorough testing and discussion.