### PR TITLE
Update removed datablock module

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Importing the (deprecated and removed) ``dxtbx.datablock`` module failed to display warning properly.

--- a/src/dxtbx/datablock.py
+++ b/src/dxtbx/datablock.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 
-from dxtbx.experiment_list import (
+from dxtbx.model.experiment_list import (
     BeamComparison,
     DetectorComparison,
     FormatChecker,


### PR DESCRIPTION
This attempted to import some basics from experiment_list, but was importing the wrong location.

The warning will now properly show.