### PR TITLE
Temporarily remove masking geometry warnings

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Temporarily disable verbose masking geometry warning.

--- a/src/dxtbx/masking/goniometer_shadow_masking.h
+++ b/src/dxtbx/masking/goniometer_shadow_masking.h
@@ -153,9 +153,9 @@ namespace dxtbx { namespace masking {
           }
         }
         if (!valid) {
-          std::cout << "Invalid polygon geometry (" << failure
-                    << "): " << boost::geometry::dsv(poly) << std::endl;
-          std::cout << boost::geometry::dsv(points) << std::endl;
+          // std::cout << "Invalid polygon geometry (" << failure
+          //           << "): " << boost::geometry::dsv(poly) << std::endl;
+          // std::cout << boost::geometry::dsv(points) << std::endl;
           result.push_back(shadow_points);
           continue;
         }


### PR DESCRIPTION
See #671. In some cases this has started giving (apparently harmless) spam output. We are disabling temporarily while a workshop is running.

This PR is intended to be backported but we may not need to merge to main.