### PR TITLE
Hit indices

### DIFF
--- a/src/dxtbx/format/FormatXTC.py
+++ b/src/dxtbx/format/FormatXTC.py
@@ -35,7 +35,7 @@ except TypeError:
 locator_str = """
   hits_file = None
     .type = str
-    .help = path to a file where each line is an index in the XTC stream of a crystal hit
+    .help = path to a file where each line is 2 numbers separated by a space, a run index, and an event index in the XTC stream
   experiment = None
     .type = str
     .help = Experiment identifier, e.g. mfxo1916


### PR DESCRIPTION
When you know the hits in an XTC stream, and you only want to reprocess those hits, skip reading the other data

This seems to work well, only it fails for multi-run datasources. And by fails, I mean, the indexing gets screwed up. Possibly a psana issue