### PR TITLE
Tweak gain for ELDICO ED-1

### DIFF
--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,1 @@
+``FormatBrukerED1``: the gain is not well-known, so reset to 1.0 and allow the user to override at import.

--- a/src/dxtbx/format/FormatCBFMiniEigerQuadroED1.py
+++ b/src/dxtbx/format/FormatCBFMiniEigerQuadroED1.py
@@ -131,11 +131,12 @@ class FormatCBFMiniEigerQuadroED1(FormatCBFMiniEiger):
             mask=[],
         )
 
-        # Here we set specifics, notably gain=3, also parallax correction and
+        # Here we set specifics: parallax correction and
         # QE correction are effectively disabled by setting the simple
-        # pixel-to-millimetre strategy and a very high mu value.
+        # pixel-to-millimetre strategy and a very high mu value. Gain is not
+        # precisely known. We think it might be around 1.7, but here will leave
+        # as 1.0 and expect the user to override at import.
         for panel in detector:
-            panel.set_gain(3)
             panel.set_thickness(thickness)
             panel.set_material(material)
             panel.set_identifier(identifier)


### PR DESCRIPTION
Following discussion with ELDICO it seems the previously assumed gain of 3.0 is not realy verified. The gain appears closer to 1.7-1.8, but this is not precisely known either. Rather than making bad assumptions, just reset to 1.0 and allow the user to override at import.