### PR TITLE
`FormatMRC` invert slow axis for non-FEI files

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+``FormatMRC``: invert the slow axis for non-ThermoFisher (FEI) files.


### PR DESCRIPTION
As [pointed out](https://github.com/huwjenkins/em_image_conversions/wiki/Y%E2%80%90axis-flips-in-conversion-to-MRC-using-EMAN2-and-IMOD) by @huwjenkins, there is a lack of consensus regarding the position of the origin for images represented by MRC files. Software like IMOD and EMAN2 take the origin at bottom left, whereas ThermoFisher adopts the typical raster-scan convention of having the origin at the upper-left.

I think this is a symptom of the abuse of MRC (a map data format) to hold image data.

Anyway, we _suspect_ that any data from a non-FEI source (i.e. lacking the `FEI` extended header) will use the bottom-left convention. This change ensures that by inverting the direction of the slow axis. Then also the distance must be inverted. Note, the actual image array is left unchanged.

A minor annoyance for non-FEI images is that if you want to override the distance at import you will have to provide a negative distance.