### PR TITLE
Create dxtbx.any2nexus dispatcher through setuptools

### DIFF
--- a/build.py
+++ b/build.py
@@ -37,7 +37,10 @@ def get_entry_point(filename: Path, prefix: str, import_path: str) -> List[str]:
     tree = ast.parse(contents)
     # Find root functions named "run"
     has_run = any(
-        x for x in tree.body if isinstance(x, ast.FunctionDef) and x.name == "run"
+        x
+        for x in tree.body
+        if (isinstance(x, ast.FunctionDef) and x.name == "run")
+        or (isinstance(x, ast.ImportFrom) and "run" in [a.name for a in x.names])
     )
     if not has_run:
         return []

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Add any2nexus to formal dispatcher mechanisms.

--- a/src/dxtbx/format/nxmx_writer.py
+++ b/src/dxtbx/format/nxmx_writer.py
@@ -820,7 +820,7 @@ class NXmxWriter:
         )
 
 
-def run(args):
+def run(args: list[str] | None = None):
     usage = "dials.python nxmx_writer.py <experiments OR image files>"
     parser = ArgumentParser(
         usage=usage,


### PR DESCRIPTION
Previously, this was only created through libtbx build mechanisms, because the build script looked for defined `run` functions, not imported ones.