### PR TITLE
Extra checks for reading pickle files

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Add fix for pickle files

--- a/src/dxtbx/format/FormatPYmultitile.py
+++ b/src/dxtbx/format/FormatPYmultitile.py
@@ -20,7 +20,7 @@ class FormatPYmultitile(FormatPY):
             with FormatPYmultitile.open_file(image_file, "rb") as fh:
                 data = pickle.load(fh, encoding="bytes")
                 data = image_dict_to_unicode(data)
-        except OSError:
+        except (AttributeError, OSError):
             return False
 
         wanted_header_items = ["TILES", "METROLOGY"]

--- a/src/dxtbx/format/FormatPYunspecified.py
+++ b/src/dxtbx/format/FormatPYunspecified.py
@@ -27,7 +27,7 @@ class FormatPYunspecified(FormatPY):
             with FormatPYunspecified.open_file(image_file, "rb") as fh:
                 data = pickle.load(fh, encoding="bytes")
                 data = image_dict_to_unicode(data)
-        except OSError:
+        except (AttributeError, OSError):
             return False
 
         headers = set(data)


### PR DESCRIPTION
This allows the registry to ignore dials mask files for these classes