### PR TITLE
DIALS 3.21.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.21.0
+current_version = 3.21.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<release>[a-z]+)?(?P<patch>\d+)?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.21.1 (2024-08-23)
+=========================
+
+Bugfixes
+--------
+
+- Stop ``dxtbx.image_average`` shuffling panel positions for segmented detectors. (`#752 <https://github.com/cctbx/dxtbx/issues/752>`_)
+
+
 dxtbx 3.21.0 (2024-08-20)
 =========================
 

--- a/newsfragments/752.bugfix
+++ b/newsfragments/752.bugfix
@@ -1,0 +1,1 @@
+Stop ``dxtbx.image_average`` shuffling panel positions for segmented detectors.

--- a/newsfragments/752.bugfix
+++ b/newsfragments/752.bugfix
@@ -1,1 +1,0 @@
-Stop ``dxtbx.image_average`` shuffling panel positions for segmented detectors.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from build import build
 
 # Static version number which is updated by bump2version
 # Do not change this manually - use 'bump2version <major/minor/patch/release>'
-__version_tag__ = "3.21.0"
+__version_tag__ = "3.21.1"
 
 setup_kwargs = {
     "name": "dxtbx",


### PR DESCRIPTION
Bugfixes
--------

- Stop ``dxtbx.image_average`` shuffling panel positions for segmented detectors. (cctbx/dxtbx#752)